### PR TITLE
Merge GH-24 into develop

### DIFF
--- a/src/main/java/net/sparkzz/command/ShopCommand.java
+++ b/src/main/java/net/sparkzz/command/ShopCommand.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -85,8 +86,8 @@ public class ShopCommand extends CommandManager {
                         .map(m -> m.toString().toLowerCase()).collect(Collectors.toList());
             }
 
-            Store currentStore = InventoryManagementSystem.locateCurrentStore(((Player) sender));
-            Set<Material> shopItems = (currentStore != null ? currentStore.getItems().keySet() : Collections.emptySet());
+            Optional<Store> currentStore = InventoryManagementSystem.locateCurrentStore(((Player) sender));
+            Set<Material> shopItems = (currentStore.isPresent() ? currentStore.get().getItems().keySet() : Collections.emptySet());
 
             // Buy/Remove command autocomplete item list
             if (args[0].equalsIgnoreCase("buy") || args[0].equalsIgnoreCase("remove"))

--- a/src/main/java/net/sparkzz/command/SubCommand.java
+++ b/src/main/java/net/sparkzz/command/SubCommand.java
@@ -1,5 +1,6 @@
 package net.sparkzz.command;
 
+import net.sparkzz.shops.Shops;
 import net.sparkzz.shops.Store;
 import net.sparkzz.util.Notifiable;
 import org.bukkit.command.Command;
@@ -8,7 +9,6 @@ import org.bukkit.command.CommandSender;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Interface for sub command layout
@@ -40,20 +40,7 @@ public abstract class SubCommand extends Notifiable {
      * @param nameOrUUID input name or UUID
      * @return the optional store if found or optional empty if not found or duplicates are found
      */
-    protected Optional<Store> identifyStore(String nameOrUUID) {
-        Optional<Store> store = Optional.empty();
-
-        if (nameOrUUID.contains("~")) {
-            String[] input = nameOrUUID.split("~");
-
-            stores = Store.STORES.stream().filter(s -> s.getName().equalsIgnoreCase(input[0]) && s.getUUID().toString().equalsIgnoreCase(input[1])).collect(Collectors.toCollection(ArrayList::new));
-        } else {
-            stores = Store.STORES.stream().filter(s -> s.getName().equalsIgnoreCase(nameOrUUID) || s.getUUID().toString().equalsIgnoreCase(nameOrUUID)).collect(Collectors.toCollection(ArrayList::new));
-        }
-
-        if (stores.size() == 1)
-            store = Optional.of(stores.get(0));
-
-        return store;
+    protected Optional<Store> identifyStore(String nameOrUUID) throws Shops.MultipleStoresMatchedException {
+        return Store.identifyStore(nameOrUUID);
     }
 }

--- a/src/main/java/net/sparkzz/command/sub/AddCommand.java
+++ b/src/main/java/net/sparkzz/command/sub/AddCommand.java
@@ -26,7 +26,7 @@ public class AddCommand extends SubCommand {
         setArgsAsAttributes(args);
         Material material = (Material) setAttribute("material", Material.matchMaterial(args[1]));
         Player player = (Player) setAttribute("sender", sender);
-        Store store = (Store) setAttribute("store", InventoryManagementSystem.locateCurrentStore(player));
+        Store store = (Store) setAttribute("store", InventoryManagementSystem.locateCurrentStore(player).orElse(null));
         int quantity = (Integer) setAttribute("quantity", 0);
         String message = "";
 

--- a/src/main/java/net/sparkzz/command/sub/BrowseCommand.java
+++ b/src/main/java/net/sparkzz/command/sub/BrowseCommand.java
@@ -8,8 +8,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import static net.sparkzz.util.Notifier.CipherKey.INVALID_PAGE_NUM;
-import static net.sparkzz.util.Notifier.CipherKey.NO_STORE_FOUND;
+import static net.sparkzz.util.Notifier.CipherKey.*;
 
 /**
  * Browse subcommand used for browsing items to a shop
@@ -24,7 +23,7 @@ public class BrowseCommand extends SubCommand {
         resetAttributes();
         setArgsAsAttributes(args);
         Player player = (Player) setAttribute("sender", sender);
-        Store store = (Store) setAttribute("store", InventoryManagementSystem.locateCurrentStore(player));
+        Store store = (Store) setAttribute("store", InventoryManagementSystem.locateCurrentStore(player).orElse(null));
 
         if (store == null) {
             Notifier.process(player, NO_STORE_FOUND, getAttributes());
@@ -32,6 +31,11 @@ public class BrowseCommand extends SubCommand {
         }
 
         int pageNumber = (args.length > 1) ? Integer.parseInt(args[1]) : 1;
+
+        if (store.getItems().isEmpty()) {
+            Notifier.process(sender, STORE_NO_ITEMS, getAttributes());
+            return true;
+        }
 
         String page = Notifier.Paginator.buildBrowsePage(store, pageNumber);
 

--- a/src/main/java/net/sparkzz/command/sub/BuyCommand.java
+++ b/src/main/java/net/sparkzz/command/sub/BuyCommand.java
@@ -28,7 +28,7 @@ public class BuyCommand extends SubCommand {
         Material material = (Material) setAttribute("material", Material.matchMaterial(args[1]));
         Player player = (Player) setAttribute("sender", sender);
         int quantity = (Integer) setAttribute("quantity", 1);
-        Store store = (Store) setAttribute("store", InventoryManagementSystem.locateCurrentStore(player));
+        Store store = (Store) setAttribute("store", InventoryManagementSystem.locateCurrentStore(player).orElse(null));
 
         if (store == null) {
             Notifier.process(player, NO_STORE_FOUND, getAttributes());

--- a/src/main/java/net/sparkzz/command/sub/CreateCommand.java
+++ b/src/main/java/net/sparkzz/command/sub/CreateCommand.java
@@ -104,7 +104,6 @@ public class CreateCommand extends SubCommand {
             double limitMaxY = (double) setAttribute("limit-max-y", maxDims[1]);
             double limitMaxZ = (double) setAttribute("limit-max-z", maxDims[2]);
 
-            // TODO: make 0 or negative limits ignore check
             if ((maxX - minX) < limitMinX || (maxY - minY) < limitMinY || (maxZ - minZ) < limitMinZ) {
                 Notifier.process(sender, Notifier.CipherKey.STORE_CREATE_FAIL_MIN_DIMS, getAttributes());
                 return true;

--- a/src/main/java/net/sparkzz/command/sub/DeleteCommand.java
+++ b/src/main/java/net/sparkzz/command/sub/DeleteCommand.java
@@ -25,65 +25,65 @@ public class DeleteCommand extends SubCommand {
     @Override
     public boolean process(CommandSender sender, Command command, String label, String[] args)
             throws NumberFormatException {
-        resetAttributes();
-        setArgsAsAttributes(args);
-        Optional<Store> foundStore = identifyStore(args[1]);
-        setAttribute("sender", sender);
-        setAttribute("store", (foundStore.isPresent() ? foundStore.get() : args[1]));
+        try {
+            resetAttributes();
+            setArgsAsAttributes(args);
+            Optional<Store> foundStore = identifyStore(args[1]);
+            setAttribute("sender", sender);
+            setAttribute("store", (foundStore.isPresent() ? foundStore.get() : args[1]));
 
-        if (stores.size() > 1) {
-            Notifier.process(sender, STORE_MULTI_MATCH, getAttributes());
-            return true;
-        }
-
-        if (foundStore.isEmpty()) {
-            Notifier.process(sender, STORE_NO_STORE_FOUND, getAttributes());
-            return true;
-        }
-
-        boolean ignoreInv = false, ignoreFunds = false;
-
-        // TODO: determine a way to check if a player can remove all items from the shop, if they can, remove them all
-        // TODO: add force flags (-f will ignore all inventory, then process) (-F will ignore all inventory and finances, then process)
-        if (args.length == 3) {
-            switch (args[2]) {
-                // soft force delete
-                case "-f" -> ignoreInv = true;
-                // hard force delete
-                case "-F" -> {
-                    ignoreInv = true;
-                    ignoreFunds = true;
-                }
-                default -> {}
+            if (foundStore.isEmpty()) {
+                Notifier.process(sender, STORE_NO_STORE_FOUND, getAttributes());
+                return true;
             }
+
+            boolean ignoreInv = false, ignoreFunds = false;
+
+            // TODO: determine a way to check if a player can remove all items from the shop, if they can, remove them all
+            // TODO: add force flags (-f will ignore all inventory, then process) (-F will ignore all inventory and finances, then process)
+            if (args.length == 3) {
+                switch (args[2]) {
+                    // soft force delete
+                    case "-f" -> ignoreInv = true;
+                    // hard force delete
+                    case "-F" -> {
+                        ignoreInv = true;
+                        ignoreFunds = true;
+                    }
+                    default -> {
+                    }
+                }
+            }
+
+            boolean canInsertAll = false;
+            Store store = foundStore.get();
+            Player player = (Player) sender;
+
+            setAttribute("store", store.getName());
+
+            if (!ignoreInv)
+                canInsertAll = InventoryManagementSystem.canInsertAll(player, store.getItems().entrySet().stream()
+                        .map(entry -> new ItemStack(entry.getKey(), (int) entry.getValue().getOrDefault("quantity", 0)))
+                        .collect(Collectors.toList()));
+
+            if (!ignoreInv && !canInsertAll) {
+                Notifier.process(sender, STORE_DELETE_INSUFFICIENT_INV_PLAYER, getAttributes());
+                return true;
+            }
+
+            if (!ignoreFunds) {
+                Shops.getEconomy().depositPlayer(player, store.getBalance());
+                store.setBalance(0);
+            }
+
+            boolean success = Store.STORES.remove(store);
+
+            if (success)
+                Notifier.process(sender, STORE_DELETE_SUCCESS, getAttributes());
+            else Notifier.process(sender, STORE_DELETE_FAIL, getAttributes());
+        } catch (Shops.MultipleStoresMatchedException exception) {
+            Notifier.process(sender, STORE_MULTI_MATCH, getAttributes());
         }
-
-        boolean canInsertAll = false;
-        Store store = foundStore.get();
-        Player player = (Player) sender;
-
-        setAttribute("store", store.getName());
-
-        if (!ignoreInv)
-            canInsertAll = InventoryManagementSystem.canInsertAll(player, store.getItems().entrySet().stream()
-                    .map(entry -> new ItemStack(entry.getKey(), (int) entry.getValue().getOrDefault("quantity", 0)))
-                    .collect(Collectors.toList()));
-
-        if (!ignoreInv && !canInsertAll) {
-            Notifier.process(sender, STORE_DELETE_INSUFFICIENT_INV_PLAYER, getAttributes());
-            return true;
-        }
-
-        if (!ignoreFunds) {
-            Shops.getEconomy().depositPlayer(player, store.getBalance());
-            store.setBalance(0);
-        }
-
-        boolean success = Store.STORES.remove(store);
-
-        if (success)
-            Notifier.process(sender, STORE_DELETE_SUCCESS, getAttributes());
-        else Notifier.process(sender, STORE_DELETE_FAIL, getAttributes());
         return true;
     }
 }

--- a/src/main/java/net/sparkzz/command/sub/DepositCommand.java
+++ b/src/main/java/net/sparkzz/command/sub/DepositCommand.java
@@ -24,7 +24,7 @@ public class DepositCommand extends SubCommand {
         resetAttributes();
         setArgsAsAttributes(args);
         Player player = (Player) setAttribute("sender", sender);
-        Store store = (Store) setAttribute("store", InventoryManagementSystem.locateCurrentStore(player));
+        Store store = (Store) setAttribute("store", InventoryManagementSystem.locateCurrentStore(player).orElse(null));
         double amount = (Double) setAttribute("amount", Double.parseDouble(args[1]));
 
         if (store == null) {

--- a/src/main/java/net/sparkzz/command/sub/RemoveCommand.java
+++ b/src/main/java/net/sparkzz/command/sub/RemoveCommand.java
@@ -26,7 +26,7 @@ public class RemoveCommand extends SubCommand {
         setArgsAsAttributes(args);
         Material material = (Material) setAttribute("material", Material.matchMaterial(args[1]));
         Player player = (Player) setAttribute("sender", sender);
-        Store store = (Store) setAttribute("store", InventoryManagementSystem.locateCurrentStore(player));
+        Store store = (Store) setAttribute("store", InventoryManagementSystem.locateCurrentStore(player).orElse(null));
 
         if (store == null) {
             Notifier.process(player, NO_STORE_FOUND, getAttributes());

--- a/src/main/java/net/sparkzz/command/sub/SellCommand.java
+++ b/src/main/java/net/sparkzz/command/sub/SellCommand.java
@@ -27,7 +27,7 @@ public class SellCommand extends SubCommand {
         setArgsAsAttributes(args);
         Material material = (Material) setAttribute("material", Material.matchMaterial(args[1]));
         Player player = (Player) setAttribute("sender", sender);
-        Store store = (Store) setAttribute("store", InventoryManagementSystem.locateCurrentStore(player));
+        Store store = (Store) setAttribute("store", InventoryManagementSystem.locateCurrentStore(player).orElse(null));
         int quantity = (Integer) setAttribute("quantity", 1);
 
         if (store == null) {

--- a/src/main/java/net/sparkzz/command/sub/TransferCommand.java
+++ b/src/main/java/net/sparkzz/command/sub/TransferCommand.java
@@ -25,54 +25,54 @@ public class TransferCommand extends SubCommand {
     @Override
     public boolean process(CommandSender sender, Command command, String label, String[] args)
             throws NumberFormatException {
-        resetAttributes();
-        setArgsAsAttributes(args);
-        setAttribute("sender", sender);
-        Optional<Store> foundStore = identifyStore(args[1]);
-        setAttribute("store", (foundStore.isPresent() ? foundStore.get() : args[1]));
+        try {
+            resetAttributes();
+            setArgsAsAttributes(args);
+            setAttribute("sender", sender);
+            Optional<Store> foundStore;
+                foundStore = identifyStore(args[1]);
+            setAttribute("store", (foundStore.isPresent() ? foundStore.get() : args[1]));
 
-        if (stores.size() > 1) {
-            Notifier.process(sender, STORE_MULTI_MATCH, getAttributes());
-            return true;
-        }
-
-        if (foundStore.isEmpty()) {
-            Notifier.process(sender, STORE_NO_STORE_FOUND, getAttributes());
-            return true;
-        }
-
-        boolean isUUID = args[2].matches("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
-
-        // TODO: remove mock references once Server mocking is updated to fix issues with getServer()
-        setAttribute("target", args[2]);
-        Server server = (!Shops.isTest()) ? Shops.getPlugin(Shops.class).getServer() : Shops.getMockServer();
-        OfflinePlayer targetPlayer = (!isUUID) ? server.getPlayer(args[2]) : server.getOfflinePlayer(UUID.fromString(args[2]));
-
-        if (targetPlayer == null) {
-            Notifier.process(sender, PLAYER_NOT_FOUND, getAttributes());
-            return true;
-        }
-
-        Store store = foundStore.get();
-
-        setAttribute("target", targetPlayer.getName());
-
-        if (!sender.isOp()) {
-            int shopsOwned = 0;
-
-            for (Store existingStore : Store.STORES)
-                if (existingStore.getOwner().equals(targetPlayer.getUniqueId())) {
-                    shopsOwned++;
-                }
-
-            if (shopsOwned >= (int) setAttribute("max-stores", Config.getMaxOwnedStores())) {
-                Notifier.process(sender, Notifier.CipherKey.STORE_TRANSFER_FAIL_MAX_STORES, getAttributes());
+            if (foundStore.isEmpty()) {
+                Notifier.process(sender, STORE_NO_STORE_FOUND, getAttributes());
                 return true;
             }
-        }
 
-        store.setOwner(targetPlayer.getUniqueId());
-        Notifier.process(sender, STORE_TRANSFER_SUCCESS, getAttributes());
+            boolean isUUID = args[2].matches("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+
+            // TODO: remove mock references once Server mocking is updated to fix issues with getServer()
+            setAttribute("target", args[2]);
+            Server server = (!Shops.isTest()) ? Shops.getPlugin(Shops.class).getServer() : Shops.getMockServer();
+            OfflinePlayer targetPlayer = (!isUUID) ? server.getPlayer(args[2]) : server.getOfflinePlayer(UUID.fromString(args[2]));
+
+            if (targetPlayer == null) {
+                Notifier.process(sender, PLAYER_NOT_FOUND, getAttributes());
+                return true;
+            }
+
+            Store store = foundStore.get();
+
+            setAttribute("target", targetPlayer.getName());
+
+            if (!sender.isOp()) {
+                int shopsOwned = 0;
+
+                for (Store existingStore : Store.STORES)
+                    if (existingStore.getOwner().equals(targetPlayer.getUniqueId())) {
+                        shopsOwned++;
+                    }
+
+                if (shopsOwned >= (int) setAttribute("max-stores", Config.getMaxOwnedStores())) {
+                    Notifier.process(sender, Notifier.CipherKey.STORE_TRANSFER_FAIL_MAX_STORES, getAttributes());
+                    return true;
+                }
+            }
+
+            store.setOwner(targetPlayer.getUniqueId());
+            Notifier.process(sender, STORE_TRANSFER_SUCCESS, getAttributes());
+        } catch (Shops.MultipleStoresMatchedException exception) {
+            Notifier.process(sender, STORE_MULTI_MATCH, getAttributes());
+        }
         return true;
     }
 }

--- a/src/main/java/net/sparkzz/command/sub/UpdateCommand.java
+++ b/src/main/java/net/sparkzz/command/sub/UpdateCommand.java
@@ -31,7 +31,7 @@ public class UpdateCommand extends SubCommand {
         resetAttributes();
         setArgsAsAttributes(args);
         Player player = (Player) setAttribute("sender", sender);
-        Store store = (Store) setAttribute("store", InventoryManagementSystem.locateCurrentStore(player));
+        Store store = (Store) setAttribute("store", InventoryManagementSystem.locateCurrentStore(player).orElse(null));
 
         if (args.length >= 8 && args[1].equalsIgnoreCase("location")) {
             switch (args.length) {

--- a/src/main/java/net/sparkzz/command/sub/WithdrawCommand.java
+++ b/src/main/java/net/sparkzz/command/sub/WithdrawCommand.java
@@ -24,7 +24,7 @@ public class WithdrawCommand extends SubCommand {
         resetAttributes();
         setArgsAsAttributes(args);
         Player player = (Player) setAttribute("sender", sender);
-        Store store = (Store) setAttribute("store", InventoryManagementSystem.locateCurrentStore(player));
+        Store store = (Store) setAttribute("store", InventoryManagementSystem.locateCurrentStore(player).orElse(null));
         double amount = (Double) setAttribute("amount", (args[1].equalsIgnoreCase("all")) ? store.getBalance() : Double.parseDouble(args[1]));
 
         if (store == null) {

--- a/src/main/java/net/sparkzz/command/sub/WithdrawCommand.java
+++ b/src/main/java/net/sparkzz/command/sub/WithdrawCommand.java
@@ -25,7 +25,7 @@ public class WithdrawCommand extends SubCommand {
         setArgsAsAttributes(args);
         Player player = (Player) setAttribute("sender", sender);
         Store store = (Store) setAttribute("store", InventoryManagementSystem.locateCurrentStore(player).orElse(null));
-        double amount = (Double) setAttribute("amount", (args[1].equalsIgnoreCase("all")) ? store.getBalance() : Double.parseDouble(args[1]));
+        double amount = (Double) setAttribute("amount", (args[1].equalsIgnoreCase("all")) ? (store == null) ? 0 : store.getBalance() : Double.parseDouble(args[1]));
 
         if (store == null) {
             Notifier.process(player, NO_STORE_FOUND, getAttributes());

--- a/src/main/java/net/sparkzz/event/EntranceListener.java
+++ b/src/main/java/net/sparkzz/event/EntranceListener.java
@@ -46,8 +46,9 @@ public class EntranceListener extends Notifiable implements Listener {
             playerStoreStatus.put(player, true);
             Notifier.process(player, Notifier.CipherKey.STORE_WELCOME_MSG, getAttributes());
         } else if (!isInShop && playerStoreStatus.getOrDefault(player, true)) {
+            if (playerStoreStatus.containsKey(player))
+                Notifier.process(player, Notifier.CipherKey.STORE_GOODBYE_MSG, getAttributes());
             playerStoreStatus.put(player, false);
-            Notifier.process(player, Notifier.CipherKey.STORE_GOODBYE_MSG, getAttributes());
         }
     }
 }

--- a/src/main/java/net/sparkzz/shops/Shops.java
+++ b/src/main/java/net/sparkzz/shops/Shops.java
@@ -143,4 +143,13 @@ public class Shops extends JavaPlugin {
     public static void setMockServer(Server mockServer) {
         server = mockServer;
     }
+
+    /**
+     * Exception for matching multiple Stores when expecting a single Store
+     */
+    public static class MultipleStoresMatchedException extends RuntimeException {
+        public MultipleStoresMatchedException(String message) {
+            super(message);
+        }
+    }
 }

--- a/src/main/java/net/sparkzz/util/Config.java
+++ b/src/main/java/net/sparkzz/util/Config.java
@@ -1,13 +1,16 @@
 package net.sparkzz.util;
 
 import net.sparkzz.shops.Shops;
+import net.sparkzz.shops.Store;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.configurate.CommentedConfigurationNode;
 import org.spongepowered.configurate.serialize.SerializationException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.logging.Logger;
 
 /**
@@ -154,6 +157,27 @@ public class Config {
     }
 
     /**
+     * Gets the default Store for the input world
+     *
+     * @param world the world to get the default Store from
+     * @return the default Store for the input world
+     */
+    public static Optional<Store> getDefaultStore(@Nullable World world) {
+        CommentedConfigurationNode defaults = rootNode.node("store").node("default");
+
+        if (defaults.hasChild("null"))
+            return Store.identifyStore(defaults.node("null").getString());
+
+        if (defaults.hasChild(world.getName())) {
+            return Store.identifyStore(defaults.node(world.getName()).getString());
+        } else if (defaults.hasChild(world.getUID())) {
+            return Store.identifyStore(defaults.node(world.getUID()).getString());
+        }
+
+        return Optional.empty();
+    }
+
+    /**
      * Gets the custom response message to be sent to the player in place of the defaults
      *
      * @param key the CipherKey to be used as the map key
@@ -181,6 +205,32 @@ public class Config {
             offLimitsNode.setList(String.class, offLimitsAreas);
         } catch (SerializationException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Sets the default Store for a selected world
+     *
+     * @param world the world to have the Store associated with
+     * @param store the Store to be associated with the input world
+     */
+    public static void setDefaultStore(@Nullable World world, @Nullable Store store) {
+        try {
+            CommentedConfigurationNode defaults = rootNode.node("store", "default");
+
+            if (store == null) {
+                defaults.removeChild((world == null) ? "'null'" : world.getName());
+                return;
+            }
+
+            if (world == null) {
+                defaults.node("'null'", store.getUUID());
+                return;
+            }
+
+            defaults.node(world.getName()).set(store.getUUID());
+        } catch (SerializationException exception) {
+            log.warning(String.format("Unable to set default store: (World: %s, Store: %s)", world, store));
         }
     }
 

--- a/src/main/java/net/sparkzz/util/Config.java
+++ b/src/main/java/net/sparkzz/util/Config.java
@@ -163,15 +163,21 @@ public class Config {
      * @return the default Store for the input world
      */
     public static Optional<Store> getDefaultStore(@Nullable World world) {
+        if (!rootNode.node("store").hasChild("default"))
+            return Optional.empty();
+
         CommentedConfigurationNode defaults = rootNode.node("store").node("default");
 
-        if (defaults.hasChild("null"))
-            return Store.identifyStore(defaults.node("null").getString());
+        if (defaults.hasChild("'null'"))
+            return Store.identifyStore(defaults.node("'null'").getString());
 
-        if (defaults.hasChild(world.getName())) {
-            return Store.identifyStore(defaults.node(world.getName()).getString());
-        } else if (defaults.hasChild(world.getUID())) {
-            return Store.identifyStore(defaults.node(world.getUID()).getString());
+        String name = (world == null) ? "'null'" : world.getName();
+        String uuid = (world == null) ? "'null'" : world.getUID().toString();
+
+        if (defaults.hasChild(uuid)) {
+            return Store.identifyStore(defaults.node(uuid).getString());
+        } else if (defaults.hasChild(name)) {
+            return Store.identifyStore(defaults.node(name).getString());
         }
 
         return Optional.empty();
@@ -196,6 +202,7 @@ public class Config {
         try {
             CommentedConfigurationNode offLimitsNode = rootNode.node("store", "off-limits");
             List<String> offLimitsAreas = offLimitsNode.getList(String.class);
+
             if (offLimitsAreas == null)
                 offLimitsAreas = new ArrayList<>();
 
@@ -223,8 +230,8 @@ public class Config {
                 return;
             }
 
-            if (world == null) {
-                defaults.node("'null'", store.getUUID());
+            if (world == null || world.getName().equalsIgnoreCase("null")) {
+                defaults.node("'null'").set(store.getUUID().toString());
                 return;
             }
 

--- a/src/main/java/net/sparkzz/util/Config.java
+++ b/src/main/java/net/sparkzz/util/Config.java
@@ -168,11 +168,11 @@ public class Config {
 
         CommentedConfigurationNode defaults = rootNode.node("store").node("default");
 
-        if (defaults.hasChild("'null'"))
-            return Store.identifyStore(defaults.node("'null'").getString());
+        if (defaults.hasChild("null"))
+            return Store.identifyStore(defaults.node("null").getString());
 
-        String name = (world == null) ? "'null'" : world.getName();
-        String uuid = (world == null) ? "'null'" : world.getUID().toString();
+        String name = (world == null) ? "null" : world.getName();
+        String uuid = (world == null) ? "null" : world.getUID().toString();
 
         if (defaults.hasChild(uuid)) {
             return Store.identifyStore(defaults.node(uuid).getString());
@@ -226,12 +226,12 @@ public class Config {
             CommentedConfigurationNode defaults = rootNode.node("store", "default");
 
             if (store == null) {
-                defaults.removeChild((world == null) ? "'null'" : world.getName());
+                defaults.removeChild((world == null) ? "null" : world.getName());
                 return;
             }
 
             if (world == null || world.getName().equalsIgnoreCase("null")) {
-                defaults.node("'null'").set(store.getUUID().toString());
+                defaults.node("null").set(store.getUUID().toString());
                 return;
             }
 

--- a/src/main/java/net/sparkzz/util/InventoryManagementSystem.java
+++ b/src/main/java/net/sparkzz/util/InventoryManagementSystem.java
@@ -9,6 +9,7 @@ import org.bukkit.inventory.PlayerInventory;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Helper class to manage player and store inventory
@@ -171,12 +172,12 @@ public class InventoryManagementSystem {
      * @param player the player to have its location checked for the current store
      * @return the store the player is currently located in
      */
-    public static Store locateCurrentStore(Player player) {
-        Store store = Store.getDefaultStore();
+    public static Optional<Store> locateCurrentStore(Player player) {
+        Optional<Store> store = Store.getDefaultStore(player.getWorld());
 
         for (Store currentStore : Store.STORES) {
             if (currentStore.getCuboidLocation() != null && currentStore.getCuboidLocation().isPlayerWithin(player)) {
-                store = currentStore;
+                store = Optional.of(currentStore);
                 break;
             }
         }

--- a/src/main/java/net/sparkzz/util/Notifier.java
+++ b/src/main/java/net/sparkzz/util/Notifier.java
@@ -194,6 +194,7 @@ public class Notifier {
         STORE_DELETE_INSUFFICIENT_INV_PLAYER("§cYou don't have enough inventory space to delete the store, please try removing items first or use the '-f' flag to ignore inventory!"),
         STORE_GOODBYE_MSG("§9We hope to see you again!"),
         STORE_MULTI_MATCH("§cMultiple stores matched, please specify the store's UUID!"),
+        STORE_NO_ITEMS("§cThis store is currently empty!"),
         STORE_NO_STORE_FOUND("§cCould not find a store with the name and/or UUID of: §6{store}§c!"),
         STORE_TRANSFER_FAIL_MAX_STORES("§c{target} can't have any more stores!§f Maximum stores: {max-stores}."),
         STORE_TRANSFER_SUCCESS("§aYou have successfully transferred §6{store}§a to player §6{target}§a!"),

--- a/src/main/java/net/sparkzz/util/Transaction.java
+++ b/src/main/java/net/sparkzz/util/Transaction.java
@@ -40,7 +40,7 @@ public class Transaction extends Notifiable {
         setAttribute("material", itemStack.getType());
         setAttribute("quantity", itemStack.getAmount());
 
-        store = (Store) setAttribute("store", InventoryManagementSystem.locateCurrentStore(player));
+        store = (Store) setAttribute("store", InventoryManagementSystem.locateCurrentStore(player).orElse(null));
         cost = (double) setAttribute("cost", switch (type) {
             case PURCHASE -> (store.getBuyPrice(itemStack.getType()) * itemStack.getAmount());
             case SALE -> (store.getSellPrice(itemStack.getType()) * itemStack.getAmount());

--- a/src/main/java/net/sparkzz/util/Warehouse.java
+++ b/src/main/java/net/sparkzz/util/Warehouse.java
@@ -33,6 +33,7 @@ import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.logging.Logger;
 import java.util.stream.DoubleStream;
 
@@ -132,9 +133,19 @@ public class Warehouse {
             for (CommentedConfigurationNode currentNode : storeConfig.node("stores").childrenList())
                 STORES.add(storeMapper.load(currentNode));
 
+            Optional<Store> nullDefaultStore = Config.getDefaultStore(Bukkit.getWorld("null"));
+
+            if (nullDefaultStore.isPresent()) {
+                Store.setDefaultStore(null, nullDefaultStore.get());
+            } else {
+                for (World world : Bukkit.getWorlds()) {
+                    Optional<Store> defaultStoreForWorld = Config.getDefaultStore(world);
+
+                    defaultStoreForWorld.ifPresent(store -> Store.setDefaultStore(world, store));
+                }
+            }
+
             log.info(String.format("%d %s loaded", STORES.size(), (STORES.size() == 1) ? "shop" : "shops"));
-            if (!STORES.isEmpty())
-                Store.setDefaultStore(STORES.get(0)); // TODO: remove once stores are dynamically loaded
         } catch (SerializationException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/net/sparkzz/util/Warehouse.java
+++ b/src/main/java/net/sparkzz/util/Warehouse.java
@@ -145,7 +145,7 @@ public class Warehouse {
                 }
             }
 
-            log.info(String.format("%d %s loaded", STORES.size(), (STORES.size() == 1) ? "shop" : "shops"));
+            log.info(String.format("%d %s loaded", STORES.size(), (STORES.size() == 1) ? "store" : "stores"));
         } catch (SerializationException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,7 @@
 store:
+  default: [] # remove square brackets if setting default store(s) per world
+#    'null': d19ba2a1-0a24-4977-baee-638ee15f2ccf
+#    world: a307b2a8-cc58-4bc1-8ee4-910053ac99d2
   max-owned-stores: 1
   min-dimensions:
     x: 3

--- a/src/test/java/net/sparkzz/command/InfoCommandTest.java
+++ b/src/test/java/net/sparkzz/command/InfoCommandTest.java
@@ -37,19 +37,20 @@ class InfoCommandTest {
 
         MockBukkit.loadWith(MockVault.class, new PluginDescriptionFile("Vault", "MOCK", "net.sparkzz.shops.mocks.MockVault"));
         plugin = MockBukkit.load(Shops.class);
+        loadConfig();
 
         mrSparkzz = server.addPlayer("MrSparkzz");
         player2 = server.addPlayer();
 
         mrSparkzz.setOp(true);
-        Store.setDefaultStore(new Store("BetterBuy", mrSparkzz.getUniqueId()));
+        Store.setDefaultStore(mrSparkzz.getWorld(), new Store("BetterBuy", mrSparkzz.getUniqueId()));
     }
 
     @AfterAll
     static void tearDown() {
-        // Stop the mock server
         MockBukkit.unmock();
-        Store.setDefaultStore(null);
+        unLoadConfig();
+        Store.DEFAULT_STORES.clear();
         Store.STORES.clear();
     }
 

--- a/src/test/java/net/sparkzz/command/ShopCommandTest.java
+++ b/src/test/java/net/sparkzz/command/ShopCommandTest.java
@@ -43,6 +43,7 @@ class ShopCommandTest {
 
         MockBukkit.loadWith(MockVault.class, new PluginDescriptionFile("Vault", "MOCK", "net.sparkzz.shops.mocks.MockVault"));
         MockBukkit.load(Shops.class);
+        loadConfig();
 
         mrSparkzz = server.addPlayer("MrSparkzz");
         player = server.addPlayer();
@@ -55,9 +56,9 @@ class ShopCommandTest {
 
     @AfterAll
     static void tearDown() {
-        // Stop the mock server
         MockBukkit.unmock();
-        Store.setDefaultStore(null);
+        unLoadConfig();
+        Store.DEFAULT_STORES.clear();
         Store.STORES.clear();
     }
 
@@ -69,14 +70,14 @@ class ShopCommandTest {
 
         @BeforeEach
         void setUpShops() {
-            Store.setDefaultStore(new Store("BetterBuy", mrSparkzz.getUniqueId()));
+            Store.setDefaultStore(mrSparkzz.getWorld(), new Store("BetterBuy", mrSparkzz.getUniqueId()));
             new Store("DiscountPlus", mrSparkzz.getUniqueId());
             new Store("DiscountMinus", mrSparkzz.getUniqueId());
         }
 
         @AfterEach
         void tearDownShops() {
-            Store.setDefaultStore(null);
+            Store.DEFAULT_STORES.clear();
             Store.STORES.clear();
         }
 
@@ -140,7 +141,7 @@ class ShopCommandTest {
         @DisplayName("Test Shop - 2 args - buy tab complete")
         @Order(24)
         void testShopTabComplete_Buy2Args() {
-            Set<Material> shopItems = InventoryManagementSystem.locateCurrentStore(mrSparkzz).getItems().keySet();
+            Set<Material> shopItems = InventoryManagementSystem.locateCurrentStore(mrSparkzz).get().getItems().keySet();
 
             List<String> expectedOptions = Arrays.stream(shopItems.toArray())
                     .map(m -> m.toString().toLowerCase()).toList();
@@ -154,7 +155,7 @@ class ShopCommandTest {
         @DisplayName("Test Shop - 2 args - remove tab complete")
         @Order(25)
         void testShopTabComplete_Remove2Args() {
-            Set<Material> shopItems = InventoryManagementSystem.locateCurrentStore(mrSparkzz).getItems().keySet();
+            Set<Material> shopItems = InventoryManagementSystem.locateCurrentStore(mrSparkzz).get().getItems().keySet();
 
             List<String> expectedOptions = Arrays.stream(shopItems.toArray())
                     .map(m -> m.toString().toLowerCase()).toList();
@@ -168,7 +169,7 @@ class ShopCommandTest {
         @DisplayName("Test Shop - 2 args - update tab complete when op")
         @Order(26)
         void testShopTabComplete_Update2Args_WhenOp() {
-            Set<Material> shopItems = InventoryManagementSystem.locateCurrentStore(mrSparkzz).getItems().keySet();
+            Set<Material> shopItems = InventoryManagementSystem.locateCurrentStore(mrSparkzz).get().getItems().keySet();
 
             List<String> expectedOptions = Arrays.stream(shopItems.toArray())
                     .map(m -> m.toString().toLowerCase()).collect(Collectors.toList());
@@ -183,7 +184,7 @@ class ShopCommandTest {
         @DisplayName("Test Shop - 2 args - update tab complete when not op")
         @Order(27)
         void testShopTabComplete_Update2Args_WhenNotOp() {
-            Set<Material> shopItems = InventoryManagementSystem.locateCurrentStore(player).getItems().keySet();
+            Set<Material> shopItems = InventoryManagementSystem.locateCurrentStore(player).get().getItems().keySet();
 
             List<String> expectedOptions = Arrays.stream(shopItems.toArray())
                     .map(m -> m.toString().toLowerCase()).collect(Collectors.toList());

--- a/src/test/java/net/sparkzz/command/SubCommandTest.java
+++ b/src/test/java/net/sparkzz/command/SubCommandTest.java
@@ -19,8 +19,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import java.util.Optional;
 
-import static net.sparkzz.shops.TestHelper.printMessage;
-import static net.sparkzz.shops.TestHelper.printSuccessMessage;
+import static net.sparkzz.shops.TestHelper.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SuppressWarnings("SpellCheckingInspection")
@@ -39,18 +38,19 @@ class SubCommandTest {
 
         MockBukkit.loadWith(MockVault.class, new PluginDescriptionFile("Vault", "MOCK", "net.sparkzz.shops.mocks.MockVault"));
         MockBukkit.load(Shops.class);
+        loadConfig();
 
         PlayerMock mrSparkzz = server.addPlayer("MrSparkzz");
 
         mrSparkzz.setOp(true);
-        Store.setDefaultStore(store = new Store("BetterBuy", mrSparkzz.getUniqueId()));
+        Store.setDefaultStore(mrSparkzz.getWorld(), store = new Store("BetterBuy", mrSparkzz.getUniqueId()));
     }
 
     @AfterAll
     static void tearDown() {
-        // Stop the mock server
         MockBukkit.unmock();
-        Store.setDefaultStore(null);
+        unLoadConfig();
+        Store.DEFAULT_STORES.clear();
         Store.STORES.clear();
     }
 

--- a/src/test/java/net/sparkzz/command/sub/AddCommandTest.java
+++ b/src/test/java/net/sparkzz/command/sub/AddCommandTest.java
@@ -6,14 +6,18 @@ import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import net.sparkzz.shops.Shops;
 import net.sparkzz.shops.Store;
 import net.sparkzz.shops.mocks.MockVault;
+import net.sparkzz.util.Notifier;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.junit.jupiter.api.*;
 
+import java.util.Collections;
 import java.util.Objects;
 
 import static net.sparkzz.shops.TestHelper.*;
+import static net.sparkzz.util.Notifier.CipherKey.INVALID_MATERIAL;
+import static net.sparkzz.util.Notifier.CipherKey.MATERIAL_MISSING_STORE;
 import static org.bukkit.ChatColor.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -103,13 +107,12 @@ class AddCommandTest {
     }
 
     @Test
-    @Disabled("Disabled until MockBukkit is updated to load plugins properly (or I find a new solution)")
     @DisplayName("Test Add - material not found in shop")
     @Order(4)
     void testAddCommand_NoMaterial() {
-        mrSparkzz.getInventory().addItem(new ItemStack(Material.EMERALD, 64));
-        performCommand(mrSparkzz, "shop add emerald 1");
-        assertEquals("§cThis material doesn't currently exist in the shop, use `/shop add emerald` to add this item", mrSparkzz.nextMessage());
+        mrSparkzz.getInventory().addItem(new ItemStack(Material.STICK, 64));
+        performCommand(mrSparkzz, "shop add stick 1");
+        assertEquals(Notifier.compose(MATERIAL_MISSING_STORE, Collections.singletonMap("material", Material.STICK)), mrSparkzz.nextMessage());
         printSuccessMessage("add command - material doesn't exist");
     }
 
@@ -118,7 +121,18 @@ class AddCommandTest {
     @Order(5)
     void testRemoveCommand_InvalidMaterial() {
         performCommand(mrSparkzz, "shop add emeral 1");
-        assertEquals("§cInvalid material (emeral)!", mrSparkzz.nextMessage());
+        assertEquals(Notifier.compose(INVALID_MATERIAL, Collections.singletonMap("material", "emeral")), mrSparkzz.nextMessage());
+        assertEquals("/shop [buy|sell|browse]", mrSparkzz.nextMessage());
         printSuccessMessage("remove command test - invalid material");
+    }
+
+    @Test
+    @DisplayName("Test Add - main functionality - no store")
+    @Order(6)
+    void testDepositCommand_NoStore() {
+        Store.DEFAULT_STORES.clear();
+        performCommand(mrSparkzz, "shop add emerald 1");
+        assertEquals(Notifier.compose(Notifier.CipherKey.NO_STORE_FOUND, null), mrSparkzz.nextMessage());
+        printSuccessMessage("add command test - no store");
     }
 }

--- a/src/test/java/net/sparkzz/command/sub/AddCommandTest.java
+++ b/src/test/java/net/sparkzz/command/sub/AddCommandTest.java
@@ -33,22 +33,23 @@ class AddCommandTest {
 
         MockBukkit.loadWith(MockVault.class, new PluginDescriptionFile("Vault", "MOCK", "net.sparkzz.shops.mocks.MockVault"));
         MockBukkit.load(Shops.class);
+        loadConfig();
 
         mrSparkzz = server.addPlayer("MrSparkzz");
         player2 = server.addPlayer();
 
         mrSparkzz.setOp(true);
-        Store.setDefaultStore(new Store("BetterBuy", mrSparkzz.getUniqueId()));
-        Store.getDefaultStore().getItems().clear();
-        Store.getDefaultStore().addItem(emeralds.getType(), 10, -1, 2D, 1.5D);
-        Store.getDefaultStore().addFunds(100);
+        Store.setDefaultStore(mrSparkzz.getWorld(), new Store("BetterBuy", mrSparkzz.getUniqueId()));
+        Store.getDefaultStore(mrSparkzz.getWorld()).get().getItems().clear();
+        Store.getDefaultStore(mrSparkzz.getWorld()).get().addItem(emeralds.getType(), 10, -1, 2D, 1.5D);
+        Store.getDefaultStore(mrSparkzz.getWorld()).get().addFunds(100);
     }
 
     @AfterAll
     static void tearDown() {
-        // Stop the mock server
         MockBukkit.unmock();
-        Store.setDefaultStore(null);
+        unLoadConfig();
+        Store.DEFAULT_STORES.clear();
     }
 
     @BeforeEach
@@ -82,7 +83,7 @@ class AddCommandTest {
         performCommand(mrSparkzz, "shop add emerald 1");
         assertEquals(String.format("%sYou have successfully added %s%s%s to the shop!", GREEN, GOLD, (quantity > 0) ? String.valueOf(quantity) + GREEN + " of " + GOLD + material : material, GREEN), mrSparkzz.nextMessage());
         assertEquals(63, Objects.requireNonNull(mrSparkzz.getInventory().getItem(0)).getAmount());
-        assertEquals(11, Store.getDefaultStore().getItems().get(material).get("quantity").intValue());
+        assertEquals(11, Store.getDefaultStore(mrSparkzz.getWorld()).get().getItems().get(material).get("quantity").intValue());
         printSuccessMessage("add command test - add 1");
     }
 
@@ -97,7 +98,7 @@ class AddCommandTest {
         performCommand(mrSparkzz, "shop add emerald all");
         assertEquals(String.format("%sYou have successfully added %s%s%s to the shop!", GREEN, GOLD, (quantity > 0) ? String.valueOf(quantity) + GREEN + " of " + GOLD + material : material, GREEN), mrSparkzz.nextMessage());
         assertFalse(mrSparkzz.getInventory().contains(material));
-        assertEquals(11, Store.getDefaultStore().getItems().get(material).get("quantity").intValue());
+        assertEquals(11, Store.getDefaultStore(mrSparkzz.getWorld()).get().getItems().get(material).get("quantity").intValue());
         printSuccessMessage("add command test - add all");
     }
 

--- a/src/test/java/net/sparkzz/command/sub/BuyCommandTest.java
+++ b/src/test/java/net/sparkzz/command/sub/BuyCommandTest.java
@@ -39,26 +39,27 @@ class BuyCommandTest {
 
         MockBukkit.loadWith(MockVault.class, new PluginDescriptionFile("Vault", "MOCK", "net.sparkzz.shops.mocks.MockVault"));
         MockBukkit.load(Shops.class);
+        loadConfig();
 
         mrSparkzz = server.addPlayer("MrSparkzz");
         player2 = server.addPlayer();
 
         mrSparkzz.setOp(true);
-        Store.setDefaultStore((store = new Store("BetterBuy", mrSparkzz.getUniqueId())));
+        Store.setDefaultStore(mrSparkzz.getWorld(), (store = new Store("BetterBuy", mrSparkzz.getUniqueId())));
     }
 
     @AfterAll
     static void tearDown() {
-        // Stop the mock server
         MockBukkit.unmock();
-        Store.setDefaultStore(null);
+        unLoadConfig();
+        Store.DEFAULT_STORES.clear();
         Store.STORES.clear();
     }
 
     @BeforeEach
     void setUpBuyCommand() {
-        Store.getDefaultStore().getItems().clear();
-        Store.getDefaultStore().addItem(emeralds.getType(), emeralds.getAmount(), -1, 2D, 1.5D);
+        Store.getDefaultStore(mrSparkzz.getWorld()).get().getItems().clear();
+        Store.getDefaultStore(mrSparkzz.getWorld()).get().addItem(emeralds.getType(), emeralds.getAmount(), -1, 2D, 1.5D);
         // TODO: Shops.getEconomy().depositPlayer(mrSparkzz, 50);
     }
 

--- a/src/test/java/net/sparkzz/command/sub/CreateCommandTest.java
+++ b/src/test/java/net/sparkzz/command/sub/CreateCommandTest.java
@@ -51,10 +51,9 @@ class CreateCommandTest {
 
     @AfterAll
     static void tearDown() {
-        // Stop the mock server
         MockBukkit.unmock();
-        Store.setDefaultStore(null);
         unLoadConfig();
+        Store.DEFAULT_STORES.clear();
     }
 
     @AfterEach
@@ -64,7 +63,7 @@ class CreateCommandTest {
 
     @BeforeEach
     void setUpStore() {
-        Store.setDefaultStore(new Store("BetterBuy", mrSparkzz.getUniqueId(), new Cuboid(world, -50, 10, -25, -100, 60, -50)));
+        Store.setDefaultStore(mrSparkzz.getWorld(), new Store("BetterBuy", mrSparkzz.getUniqueId(), new Cuboid(world, -50, 10, -25, -100, 60, -50)));
     }
 
     @Test

--- a/src/test/java/net/sparkzz/command/sub/CreateCommandTest.java
+++ b/src/test/java/net/sparkzz/command/sub/CreateCommandTest.java
@@ -6,7 +6,10 @@ import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import net.sparkzz.shops.Shops;
 import net.sparkzz.shops.Store;
 import net.sparkzz.shops.mocks.MockVault;
+import net.sparkzz.util.Config;
 import net.sparkzz.util.Cuboid;
+import net.sparkzz.util.Notifier;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.WorldCreator;
 import org.bukkit.plugin.PluginDescriptionFile;
@@ -20,8 +23,11 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.util.Collections;
+import java.util.Map;
+
 import static net.sparkzz.shops.TestHelper.*;
-import static org.bukkit.ChatColor.*;
+import static net.sparkzz.util.Notifier.CipherKey.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SuppressWarnings("SpellCheckingInspection")
@@ -29,6 +35,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class CreateCommandTest {
 
+    private static double previousMaxVolume, previousMinVolume;
+    private static double[] previousMaxDimensions;
     private static PlayerMock mrSparkzz, player2;
     private static World world;
 
@@ -47,6 +55,10 @@ class CreateCommandTest {
         player2 = server.addPlayer();
 
         mrSparkzz.setOp(true);
+        mrSparkzz.setLocation(new Location(world, 0D, 0D, 0D));
+        previousMaxDimensions = Config.getMaxDimensions();
+        previousMinVolume = Config.getMinVolume();
+        previousMaxVolume = Config.getMaxVolume();
     }
 
     @AfterAll
@@ -59,6 +71,9 @@ class CreateCommandTest {
     @AfterEach
     void tearDownStore() {
         Store.STORES.clear();
+        Config.setMaxDimensions(previousMaxDimensions[0], previousMaxDimensions[1], previousMaxDimensions[2]);
+        Config.setMinVolume(previousMinVolume);
+        Config.setMaxVolume(previousMaxVolume);
     }
 
     @BeforeEach
@@ -71,7 +86,7 @@ class CreateCommandTest {
     @Order(1)
     void testCreateShop_Permissions() {
         performCommand(player2, "shop create TestShop");
-        assertEquals(String.format("%sYou do not have permission to use this command!", RED), player2.nextMessage());
+        assertEquals(Notifier.compose(NO_PERMS_CMD, null), player2.nextMessage());
         printSuccessMessage("create command permission check");
     }
 
@@ -80,7 +95,7 @@ class CreateCommandTest {
     @Order(2)
     void testCreateShop() {
         performCommand(mrSparkzz, "shop create TestShop");
-        assertEquals(String.format("%sYou have successfully created %s%s%s!", GREEN, GOLD, "TestShop", GREEN), mrSparkzz.nextMessage());
+        assertEquals(Notifier.compose(STORE_CREATE_SUCCESS, Collections.singletonMap("store", "TestShop")), mrSparkzz.nextMessage());
         printSuccessMessage("create command test - creation of TestShop");
     }
 
@@ -89,7 +104,7 @@ class CreateCommandTest {
     @Order(3)
     void testCreateShop_ForAnotherPlayer() {
         performCommand(mrSparkzz, String.format("shop create TestShop %s", player2.getName()));
-        assertEquals(String.format("§aYou have successfully created §6TestShop§a for §6%s§a!", player2.getName()), mrSparkzz.nextMessage());
+        assertEquals(Notifier.compose(STORE_CREATE_SUCCESS_OTHER_PLAYER, Map.of("store", "TestShop", "target", player2.getName())), mrSparkzz.nextMessage());
         printSuccessMessage("create command test - creation of TestShop for Player0");
     }
 
@@ -99,7 +114,7 @@ class CreateCommandTest {
     void testCreateShop_ForAnotherPlayerByUUID() {
         // TODO: create MockPermissions to add specific permissions to a player mock
         performCommand(mrSparkzz, String.format("shop create TestShop %s", player2.getUniqueId()));
-        assertEquals(String.format("§aYou have successfully created §6TestShop§a for §6%s§a!", player2.getUniqueId()), mrSparkzz.nextMessage());
+        assertEquals(Notifier.compose(STORE_CREATE_SUCCESS_OTHER_PLAYER, Map.of("store", "TestShop", "target", player2.getUniqueId())), mrSparkzz.nextMessage());
         printSuccessMessage("create command test - creation of TestShop for Player0 by UUID");
     }
 
@@ -108,7 +123,7 @@ class CreateCommandTest {
     @Order(5)
     void testCreateCommand_NoTargetPlayer() {
         performCommand(mrSparkzz, "shop create BetterBuy Player99");
-        assertEquals("§cPlayer (Player99) not found!", mrSparkzz.nextMessage());
+        assertEquals(Notifier.compose(PLAYER_NOT_FOUND, Collections.singletonMap("target", "Player99")), mrSparkzz.nextMessage());
         printSuccessMessage("create command test - target player not found");
     }
 
@@ -117,7 +132,7 @@ class CreateCommandTest {
     @Order(6)
     void testCreateCommand_CuboidShop() {
         performCommand(mrSparkzz, "shop create BetterBuy 10.5 8 -23 15 0 -37");
-        assertEquals("§aYou have successfully created §6BetterBuy§a!", mrSparkzz.nextMessage());
+        assertEquals(Notifier.compose(STORE_CREATE_SUCCESS, Collections.singletonMap("store", "BetterBuy")), mrSparkzz.nextMessage());
         printSuccessMessage("create command test - cuboid shop");
     }
 
@@ -126,7 +141,187 @@ class CreateCommandTest {
     @Order(7)
     void testCreateCommand_CuboidShop_OtherPlayer() {
         performCommand(mrSparkzz, String.format("shop create TestShop %s 10.5 8 -23 15 0 -37", player2.getUniqueId()));
-        assertEquals(String.format("§aYou have successfully created §6TestShop§a for §6%s§a!", player2.getUniqueId()), mrSparkzz.nextMessage());
+        assertEquals(Notifier.compose(STORE_CREATE_SUCCESS_OTHER_PLAYER, Map.of("store", "TestShop", "target", player2.getUniqueId())), mrSparkzz.nextMessage());
         printSuccessMessage("create command test - cuboid shop for other player");
+    }
+
+    @Test
+    @DisplayName("Test Create - main functionality - max stores")
+    @Order(8)
+    void testCreateCommand_MaxStores() {
+        new Store("store2", mrSparkzz.getUniqueId());
+        new Store("store3", mrSparkzz.getUniqueId());
+        new Store("store4", mrSparkzz.getUniqueId());
+        new Store("store5", mrSparkzz.getUniqueId());
+        performCommand(mrSparkzz, "shop create TestShop");
+        assertEquals(Notifier.compose(STORE_CREATE_FAIL_MAX_STORES, Collections.singletonMap("max-stores", Config.getMaxOwnedStores())), mrSparkzz.nextMessage());
+        printSuccessMessage("create command test - max stores");
+    }
+
+    @Test
+    @DisplayName("Test Create - main functionality - off-limits area")
+    @Order(9)
+    void testCreateCommand_CuboidShop_OffLimitsArea() {
+        performCommand(mrSparkzz, "shop create TestShop 4 0 4 16 5 16");
+        assertEquals(Notifier.compose(STORE_CREATE_FAIL_OFFLIMITS, null), mrSparkzz.nextMessage());
+        printSuccessMessage("create command test - off-limits area");
+    }
+
+    @Test
+    @DisplayName("Test Create - main functionality - overlaps other store")
+    @Order(10)
+    void testCreateCommand_CuboidShop_OverlapsExisting() {
+        new Store("GuardShop", player2.getUniqueId(), new Cuboid(world, 200, 200, 200, 220, 220, 220));
+        performCommand(mrSparkzz, "shop create TestShop 205 205 205 208 208 208");
+        assertEquals(Notifier.compose(STORE_CREATE_FAIL_OVERLAPS, null), mrSparkzz.nextMessage());
+        printSuccessMessage("create command test - off-limits area");
+    }
+
+    @Test
+    @DisplayName("Test Create - limits - under minimum X")
+    @Order(20)
+    void testCreateCommand_Limits_UnderMinimumX() {
+        performCommand(mrSparkzz, "shop create TestShop 10 12 16 11 20 40");
+        double[] minimum = Config.getMinDimensions();
+        assertEquals(Notifier.compose(STORE_CREATE_FAIL_MIN_DIMS, Map.of(
+                "limit-min-x", minimum[0],
+                "limit-min-y", minimum[1],
+                "limit-min-z", minimum[2]
+        )), mrSparkzz.nextMessage());
+        printSuccessMessage("create command test - limits - under minimum x");
+    }
+
+    @Test
+    @DisplayName("Test Create - limits - under minimum Y")
+    @Order(21)
+    void testCreateCommand_Limits_UnderMinimumY() {
+        performCommand(mrSparkzz, "shop create TestShop 10 12 16 20 13 40");
+        double[] minimum = Config.getMinDimensions();
+        assertEquals(Notifier.compose(STORE_CREATE_FAIL_MIN_DIMS, Map.of(
+                "limit-min-x", minimum[0],
+                "limit-min-y", minimum[1],
+                "limit-min-z", minimum[2]
+        )), mrSparkzz.nextMessage());
+        printSuccessMessage("create command test - limits - under minimum y");
+    }
+
+    @Test
+    @DisplayName("Test Create - limits - under minimum Z")
+    @Order(22)
+    void testCreateCommand_Limits_UnderMinimumZ() {
+        performCommand(mrSparkzz, "shop create TestShop 10 12 16 20 20 17");
+        double[] minimum = Config.getMinDimensions();
+        assertEquals(Notifier.compose(STORE_CREATE_FAIL_MIN_DIMS, Map.of(
+                "limit-min-x", minimum[0],
+                "limit-min-y", minimum[1],
+                "limit-min-z", minimum[2]
+        )), mrSparkzz.nextMessage());
+        printSuccessMessage("create command test - limits - under minimum z");
+    }
+
+    @Test
+    @DisplayName("Test Create - limits - over maximum X")
+    @Order(23)
+    void testCreateCommand_Limits_OverMinimumX() {
+        performCommand(mrSparkzz, "shop create TestShop 10 12 16 100 20 40");
+        double[] maximum = Config.getMaxDimensions();
+        assertEquals(Notifier.compose(STORE_CREATE_FAIL_MAX_DIMS, Map.of(
+                "limit-max-x", maximum[0],
+                "limit-max-y", maximum[1],
+                "limit-max-z", maximum[2]
+        )), mrSparkzz.nextMessage());
+        printSuccessMessage("create command test - limits - over maximum x");
+    }
+
+    @Test
+    @DisplayName("Test Create - limits - over maximum Y")
+    @Order(24)
+    void testCreateCommand_Limits_OverMinimumY() {
+        performCommand(mrSparkzz, "shop create TestShop 10 12 16 20 100 40");
+        double[] maximum = Config.getMaxDimensions();
+        assertEquals(Notifier.compose(STORE_CREATE_FAIL_MAX_DIMS, Map.of(
+                "limit-max-x", maximum[0],
+                "limit-max-y", maximum[1],
+                "limit-max-z", maximum[2]
+        )), mrSparkzz.nextMessage());
+        printSuccessMessage("create command test - limits - over maximum y");
+    }
+
+    @Test
+    @DisplayName("Test Create - limits - over maximum Z")
+    @Order(25)
+    void testCreateCommand_Limits_OverMinimumZ() {
+        performCommand(mrSparkzz, "shop create TestShop 10 12 16 20 20 100");
+        double[] maximum = Config.getMaxDimensions();
+        assertEquals(Notifier.compose(STORE_CREATE_FAIL_MAX_DIMS, Map.of(
+                "limit-max-x", maximum[0],
+                "limit-max-y", maximum[1],
+                "limit-max-z", maximum[2]
+        )), mrSparkzz.nextMessage());
+        printSuccessMessage("create command test - limits - over maximum z");
+    }
+
+    @Test
+    @DisplayName("Test Create - limits - zero maximum X")
+    @Order(26)
+    void testCreateCommand_Limits_ZeroMaximumX() {
+        Config.setMaxDimensions(0D, 0D ,0D);
+        Config.setMaxVolume(27000D);
+        performCommand(mrSparkzz, "shop create TestShop 120 120 120 150 150 150");
+        assertEquals(Notifier.compose(STORE_CREATE_SUCCESS, Collections.singletonMap("store", "TestShop")), mrSparkzz.nextMessage());
+        printSuccessMessage("create command test - limits - zero maximum x");
+    }
+
+    @Test
+    @DisplayName("Test Create - limits - zero maximum Y")
+    @Order(26)
+    void testCreateCommand_Limits_ZeroMaximumY() {
+        Config.setMaxDimensions(35D, 0D ,0D);
+        Config.setMaxVolume(27000D);
+        performCommand(mrSparkzz, "shop create TestShop 120 120 120 150 150 150");
+        assertEquals(Notifier.compose(STORE_CREATE_SUCCESS, Collections.singletonMap("store", "TestShop")), mrSparkzz.nextMessage());
+        printSuccessMessage("create command test - limits - zero maximum y");
+    }
+
+    @Test
+    @DisplayName("Test Create - limits - zero maximum Z")
+    @Order(26)
+    void testCreateCommand_Limits_ZeroMaximumZ() {
+        Config.setMaxDimensions(35D, 35D ,0D);
+        Config.setMaxVolume(27000D);
+        performCommand(mrSparkzz, "shop create TestShop 120 120 120 150 150 150");
+        assertEquals(Notifier.compose(STORE_CREATE_SUCCESS, Collections.singletonMap("store", "TestShop")), mrSparkzz.nextMessage());
+        printSuccessMessage("create command test - limits - zero maximum z");
+    }
+
+    @Test
+    @DisplayName("Test Create - limits - minimum volume")
+    @Order(27)
+    void testCreateCommand_Limits_MinimumVolume() {
+        Config.setMinVolume(28D);
+        performCommand(mrSparkzz, "shop create TestShop 120 120 120 123 123 123");
+        assertEquals(Notifier.compose(STORE_CREATE_FAIL_MIN_VOL, Collections.singletonMap("limit-min-vol", Config.getMinVolume())), mrSparkzz.nextMessage());
+        printSuccessMessage("create command test - limits - minimum volume");
+    }
+
+    @Test
+    @DisplayName("Test Create - limits - maximum volume")
+    @Order(28)
+    void testCreateCommand_Limits_MaximumVolume() {
+        Config.setMaxVolume(20D);
+        performCommand(mrSparkzz, "shop create TestShop 120 120 120 123 123 123");
+        assertEquals(Notifier.compose(STORE_CREATE_FAIL_MAX_VOL, Collections.singletonMap("limit-max-vol", Config.getMaxVolume())), mrSparkzz.nextMessage());
+        printSuccessMessage("create command test - limits - maximum volume");
+    }
+
+    @Test
+    @DisplayName("Test Create - main functionality - zero max volume")
+    @Order(29)
+    void testCreateCommand_Limits_ZeroMaxVolume() {
+        Config.setMaxDimensions(0D, 0D, 0D);
+        Config.setMaxVolume(0);
+        performCommand(mrSparkzz, "shop create TestShop 205 205 205 308 308 308");
+        assertEquals(Notifier.compose(STORE_CREATE_SUCCESS, Collections.singletonMap("store", "TestShop")), mrSparkzz.nextMessage());
+        printSuccessMessage("create command test - zero max volume");
     }
 }

--- a/src/test/java/net/sparkzz/command/sub/DeleteCommandTest.java
+++ b/src/test/java/net/sparkzz/command/sub/DeleteCommandTest.java
@@ -6,6 +6,7 @@ import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import net.sparkzz.shops.Shops;
 import net.sparkzz.shops.Store;
 import net.sparkzz.shops.mocks.MockVault;
+import net.sparkzz.util.Notifier;
 import org.bukkit.Material;
 import org.bukkit.command.Command;
 import org.bukkit.inventory.ItemStack;
@@ -35,19 +36,20 @@ class DeleteCommandTest {
 
         MockBukkit.loadWith(MockVault.class, new PluginDescriptionFile("Vault", "MOCK", "net.sparkzz.shops.mocks.MockVault"));
         MockBukkit.load(Shops.class);
+        loadConfig();
 
         mrSparkzz = server.addPlayer("MrSparkzz");
         player2 = server.addPlayer();
 
         mrSparkzz.setOp(true);
-        Store.setDefaultStore(new Store("BetterBuy", mrSparkzz.getUniqueId()));
+        Store.setDefaultStore(mrSparkzz.getWorld(), (new Store("BetterBuy", mrSparkzz.getUniqueId())));
     }
 
     @AfterAll
     static void tearDown() {
-        // Stop the mock server
         MockBukkit.unmock();
-        Store.setDefaultStore(null);
+        unLoadConfig();
+        Store.DEFAULT_STORES.clear();
         Store.STORES.clear();
     }
 
@@ -67,7 +69,7 @@ class DeleteCommandTest {
     @Order(1)
     void testDeleteShop_Permissions() {
         performCommand(player2, "shop delete DollHairStore");
-        assertEquals(String.format("%sYou do not have permission to use this command!", RED), player2.nextMessage());
+        assertEquals(Notifier.compose(Notifier.CipherKey.NO_PERMS_CMD, null), player2.nextMessage());
         printSuccessMessage("delete command permission check");
     }
 

--- a/src/test/java/net/sparkzz/command/sub/DepositCommandTest.java
+++ b/src/test/java/net/sparkzz/command/sub/DepositCommandTest.java
@@ -10,9 +10,10 @@ import net.sparkzz.util.Notifier;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.junit.jupiter.api.*;
 
+import java.util.Collections;
+
 import static net.sparkzz.shops.TestHelper.*;
-import static org.bukkit.ChatColor.GOLD;
-import static org.bukkit.ChatColor.GREEN;
+import static net.sparkzz.util.Notifier.CipherKey.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SuppressWarnings("SpellCheckingInspection")
@@ -36,27 +37,26 @@ class DepositCommandTest {
         player2 = server.addPlayer();
 
         mrSparkzz.setOp(true);
-        Store.setDefaultStore(mrSparkzz.getWorld(), (store = new Store("BetterBuy", mrSparkzz.getUniqueId())));
     }
 
     @AfterAll
     static void tearDown() {
         MockBukkit.unmock();
         unLoadConfig();
-        Store.DEFAULT_STORES.clear();
-        Store.STORES.clear();
     }
 
     @BeforeEach
     void setUpDepositCommand() {
+        Store.setDefaultStore(mrSparkzz.getWorld(), (store = new Store("BetterBuy", mrSparkzz.getUniqueId())));
         // TODO: Shops.getEconomy().depositPlayer(mrSparkzz, 150);
         Store.getDefaultStore(mrSparkzz.getWorld()).get().setBalance(25);
     }
 
     @AfterEach
     void tearDownWithdrawCommand() {
+        Store.DEFAULT_STORES.clear();
+        Store.STORES.clear();
         player2.setOp(false);
-        store.setInfiniteFunds(false);
     }
 
     @Test
@@ -73,10 +73,8 @@ class DepositCommandTest {
     @DisplayName("Test Deposit - main functionality - deposit 100")
     @Order(2)
     void testDepositCommand() {
-        double amount = 100;
-
-        performCommand(mrSparkzz, "shop deposit " + amount);
-        assertEquals(String.format("%sYou have successfully deposited %s%s%s to the shop!", GREEN, GOLD, amount, GREEN), mrSparkzz.nextMessage());
+        performCommand(mrSparkzz, "shop deposit 100");
+        assertEquals(Notifier.compose(DEPOSIT_SUCCESS, Collections.singletonMap("amount", 100D)), mrSparkzz.nextMessage());
         assertEquals(125, Store.getDefaultStore(mrSparkzz.getWorld()).get().getBalance());
         assertEquals(50, Shops.getEconomy().getBalance(mrSparkzz));
         printSuccessMessage("deposit command test");
@@ -100,7 +98,7 @@ class DepositCommandTest {
     void testDepositCommand_NotOwner() {
         player2.setOp(true);
         performCommand(player2, "shop deposit 100");
-        assertEquals("§cYou are not the owner of this store, you cannot perform this command!", player2.nextMessage());
+        assertEquals(Notifier.compose(NOT_OWNER, null), player2.nextMessage());
         // TODO: assertEquals(150, Shops.getEconomy().getBalance(mrSparkzz));
         assertEquals(25, store.getBalance());
         printSuccessMessage("deposit command test - not the owner");
@@ -112,7 +110,7 @@ class DepositCommandTest {
     @Order(5)
     void testDepositCommand_InsufficientFunds() {
         performCommand(mrSparkzz, "shop deposit 200");
-        assertEquals("§cYou have insufficient funds!", mrSparkzz.nextMessage());
+        assertEquals(Notifier.compose(INSUFFICIENT_FUNDS_PLAYER, null), mrSparkzz.nextMessage());
         assertEquals(125, Shops.getEconomy().getBalance(mrSparkzz));
         assertEquals(25, store.getBalance());
         printSuccessMessage("deposit command test - insufficient funds");
@@ -124,9 +122,19 @@ class DepositCommandTest {
     void testDepositCommand_InfiniteFunds() {
         store.setInfiniteFunds(true);
         performCommand(mrSparkzz, "shop deposit 15");
-        assertEquals("§aThis store has infinite funds, depositing funds isn't necessary!", mrSparkzz.nextMessage());
+        assertEquals(Notifier.compose(DEPOSIT_INF_FUNDS, null), mrSparkzz.nextMessage());
         // TODO: assertEquals(125, Shops.getEconomy().getBalance(mrSparkzz));
         assertEquals(25, store.getBalance());
         printSuccessMessage("deposit command test - shop has infinite funds");
+    }
+
+    @Test
+    @DisplayName("Test Deposit - main functionality - no store")
+    @Order(7)
+    void testDepositCommand_NoStore() {
+        Store.DEFAULT_STORES.clear();
+        performCommand(mrSparkzz, "shop deposit 100");
+        assertEquals(Notifier.compose(Notifier.CipherKey.NO_STORE_FOUND, null), mrSparkzz.nextMessage());
+        printSuccessMessage("deposit command test - no store");
     }
 }

--- a/src/test/java/net/sparkzz/command/sub/DepositCommandTest.java
+++ b/src/test/java/net/sparkzz/command/sub/DepositCommandTest.java
@@ -6,11 +6,13 @@ import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import net.sparkzz.shops.Shops;
 import net.sparkzz.shops.Store;
 import net.sparkzz.shops.mocks.MockVault;
+import net.sparkzz.util.Notifier;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.junit.jupiter.api.*;
 
 import static net.sparkzz.shops.TestHelper.*;
-import static org.bukkit.ChatColor.*;
+import static org.bukkit.ChatColor.GOLD;
+import static org.bukkit.ChatColor.GREEN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SuppressWarnings("SpellCheckingInspection")
@@ -28,26 +30,27 @@ class DepositCommandTest {
 
         MockBukkit.loadWith(MockVault.class, new PluginDescriptionFile("Vault", "MOCK", "net.sparkzz.shops.mocks.MockVault"));
         MockBukkit.load(Shops.class);
+        loadConfig();
 
         mrSparkzz = server.addPlayer("MrSparkzz");
         player2 = server.addPlayer();
 
         mrSparkzz.setOp(true);
-        Store.setDefaultStore((store = new Store("BetterBuy", mrSparkzz.getUniqueId())));
+        Store.setDefaultStore(mrSparkzz.getWorld(), (store = new Store("BetterBuy", mrSparkzz.getUniqueId())));
     }
 
     @AfterAll
     static void tearDown() {
-        // Stop the mock server
         MockBukkit.unmock();
-        Store.setDefaultStore(null);
+        unLoadConfig();
+        Store.DEFAULT_STORES.clear();
         Store.STORES.clear();
     }
 
     @BeforeEach
     void setUpDepositCommand() {
         // TODO: Shops.getEconomy().depositPlayer(mrSparkzz, 150);
-        Store.getDefaultStore().setBalance(25);
+        Store.getDefaultStore(mrSparkzz.getWorld()).get().setBalance(25);
     }
 
     @AfterEach
@@ -61,7 +64,7 @@ class DepositCommandTest {
     @Order(1)
     void testWithdrawCommand_Permissions() {
         performCommand(player2, "shop deposit 100");
-        assertEquals(String.format("%sYou do not have permission to use this command!", RED), player2.nextMessage());
+        assertEquals(Notifier.compose(Notifier.CipherKey.NO_PERMS_CMD, null), player2.nextMessage());
         printSuccessMessage("deposit command permission check");
     }
 
@@ -74,7 +77,7 @@ class DepositCommandTest {
 
         performCommand(mrSparkzz, "shop deposit " + amount);
         assertEquals(String.format("%sYou have successfully deposited %s%s%s to the shop!", GREEN, GOLD, amount, GREEN), mrSparkzz.nextMessage());
-        assertEquals(125, Store.getDefaultStore().getBalance());
+        assertEquals(125, Store.getDefaultStore(mrSparkzz.getWorld()).get().getBalance());
         assertEquals(50, Shops.getEconomy().getBalance(mrSparkzz));
         printSuccessMessage("deposit command test");
     }

--- a/src/test/java/net/sparkzz/command/sub/RemoveCommandTest.java
+++ b/src/test/java/net/sparkzz/command/sub/RemoveCommandTest.java
@@ -41,21 +41,22 @@ public class RemoveCommandTest {
 
         MockBukkit.loadWith(MockVault.class, new PluginDescriptionFile("Vault", "MOCK", "net.sparkzz.shops.mocks.MockVault"));
         MockBukkit.load(Shops.class);
+        loadConfig();
 
         mrSparkzz = server.addPlayer("MrSparkzz");
         player2 = server.addPlayer();
 
         mrSparkzz.setOp(true);
-        Store.setDefaultStore(new Store("BetterBuy", mrSparkzz.getUniqueId()));
-        Store.getDefaultStore().getItems().clear();
-        Store.getDefaultStore().addItem(emeralds.getType(), 0, -1, 2D, 1.5D);
+        Store.setDefaultStore(mrSparkzz.getWorld(), new Store("BetterBuy", mrSparkzz.getUniqueId()));
+        Store.getDefaultStore(mrSparkzz.getWorld()).get().getItems().clear();
+        Store.getDefaultStore(mrSparkzz.getWorld()).get().addItem(emeralds.getType(), 0, -1, 2D, 1.5D);
     }
 
     @AfterAll
     static void tearDown() {
-        // Stop the mock server
         MockBukkit.unmock();
-        Store.setDefaultStore(null);
+        unLoadConfig();
+        Store.DEFAULT_STORES.clear();
         Store.STORES.clear();
     }
 
@@ -78,7 +79,7 @@ public class RemoveCommandTest {
         performCommand(mrSparkzz, "shop remove emerald 1");
         assertEquals(String.format("%sYou have successfully removed %s%s%s from the shop!", GREEN, GOLD, material, GREEN), mrSparkzz.nextMessage());
         assertEquals(63, Objects.requireNonNull(mrSparkzz.getInventory().getItem(0)).getAmount());
-        assertEquals(11, Store.getDefaultStore().getItems().get(material).get("quantity").intValue());
+        assertEquals(11, Store.getDefaultStore(mrSparkzz.getWorld()).get().getItems().get(material).get("quantity").intValue());
         printSuccessMessage("remove command test - remove 1 of type from shop");
     }
 
@@ -90,7 +91,7 @@ public class RemoveCommandTest {
 
         performCommand(mrSparkzz, "shop remove emerald");
         assertEquals(String.format("%sYou have successfully removed %s%s%s from the store!", GREEN, GOLD, material, GREEN), mrSparkzz.nextMessage());
-        assertNull(Store.getDefaultStore().getItems().get(material));
+        assertNull(Store.getDefaultStore(mrSparkzz.getWorld()).get().getItems().get(material));
         printSuccessMessage("remove command test - remove all of type from shop");
     }
 

--- a/src/test/java/net/sparkzz/command/sub/RemoveCommandTest.java
+++ b/src/test/java/net/sparkzz/command/sub/RemoveCommandTest.java
@@ -107,7 +107,7 @@ public class RemoveCommandTest {
     }
 
     @Test
-    @DisplayName("Test Remove - material not found in shop")
+    @DisplayName("Test Remove - material not found in store")
     @Order(4)
     void testRemoveCommand_NoMaterial() {
         performCommand(mrSparkzz, "shop remove stick 1");

--- a/src/test/java/net/sparkzz/command/sub/RemoveCommandTest.java
+++ b/src/test/java/net/sparkzz/command/sub/RemoveCommandTest.java
@@ -6,22 +6,26 @@ import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import net.sparkzz.shops.Shops;
 import net.sparkzz.shops.Store;
 import net.sparkzz.shops.mocks.MockVault;
+import net.sparkzz.util.Notifier;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
 
 import static net.sparkzz.shops.TestHelper.*;
-import static org.bukkit.ChatColor.*;
+import static net.sparkzz.util.Notifier.CipherKey.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -47,15 +51,23 @@ public class RemoveCommandTest {
         player2 = server.addPlayer();
 
         mrSparkzz.setOp(true);
-        Store.setDefaultStore(mrSparkzz.getWorld(), new Store("BetterBuy", mrSparkzz.getUniqueId()));
-        Store.getDefaultStore(mrSparkzz.getWorld()).get().getItems().clear();
-        Store.getDefaultStore(mrSparkzz.getWorld()).get().addItem(emeralds.getType(), 0, -1, 2D, 1.5D);
     }
 
     @AfterAll
     static void tearDown() {
         MockBukkit.unmock();
         unLoadConfig();
+    }
+
+    @BeforeEach
+    void setUp() {
+        Store.setDefaultStore(mrSparkzz.getWorld(), new Store("BetterBuy", mrSparkzz.getUniqueId()));
+        Store.getDefaultStore(mrSparkzz.getWorld()).get().getItems().clear();
+        Store.getDefaultStore(mrSparkzz.getWorld()).get().addItem(emeralds.getType(), emeralds.getAmount(), -1, 2D, 1.5D);
+    }
+
+    @AfterEach
+    void tearDownEach() {
         Store.DEFAULT_STORES.clear();
         Store.STORES.clear();
     }
@@ -65,21 +77,20 @@ public class RemoveCommandTest {
     @Order(1)
     void testRemoveCommand_Permissions() {
         performCommand(player2, "shop remove acacia_log 1");
-        assertEquals(String.format("%sYou do not have permission to use this command!", RED), player2.nextMessage());
+        assertEquals(Notifier.compose(NO_PERMS_CMD, null), player2.nextMessage());
         printSuccessMessage("remove command permission check");
     }
 
     @Test
-    @Disabled("Disabled until MockBukkit is updated to load plugins properly (or I find a new solution)")
     @DisplayName("Test Remove - main functionality - remove 1")
     @Order(2)
     void testRemoveCommand_RemoveOne() {
         Material material = emeralds.getType();
 
         performCommand(mrSparkzz, "shop remove emerald 1");
-        assertEquals(String.format("%sYou have successfully removed %s%s%s from the shop!", GREEN, GOLD, material, GREEN), mrSparkzz.nextMessage());
-        assertEquals(63, Objects.requireNonNull(mrSparkzz.getInventory().getItem(0)).getAmount());
-        assertEquals(11, Store.getDefaultStore(mrSparkzz.getWorld()).get().getItems().get(material).get("quantity").intValue());
+        assertEquals(Notifier.compose(REMOVE_SUCCESS_QUANTITY, Map.of("material", Material.EMERALD, "quantity", 1)), mrSparkzz.nextMessage());
+        assertEquals(1, Objects.requireNonNull(mrSparkzz.getInventory().getItem(0)).getAmount());
+        assertEquals(63, Store.getDefaultStore(mrSparkzz.getWorld()).get().getItems().get(material).get("quantity").intValue());
         printSuccessMessage("remove command test - remove 1 of type from shop");
     }
 
@@ -90,18 +101,17 @@ public class RemoveCommandTest {
         Material material = emeralds.getType();
 
         performCommand(mrSparkzz, "shop remove emerald");
-        assertEquals(String.format("%sYou have successfully removed %s%s%s from the store!", GREEN, GOLD, material, GREEN), mrSparkzz.nextMessage());
+        assertEquals(Notifier.compose(REMOVE_SUCCESS, Collections.singletonMap("material", Material.EMERALD)), mrSparkzz.nextMessage());
         assertNull(Store.getDefaultStore(mrSparkzz.getWorld()).get().getItems().get(material));
         printSuccessMessage("remove command test - remove all of type from shop");
     }
 
     @Test
-    @Disabled("Disabled until MockBukkit is updated to load plugins properly (or I find a new solution)")
     @DisplayName("Test Remove - material not found in shop")
     @Order(4)
     void testRemoveCommand_NoMaterial() {
-        performCommand(mrSparkzz, "shop remove emerald 1");
-        assertEquals(String.format("%sThis material doesn't currently exist in the shop, use `/shop add %s` to add this item", RED, Material.EMERALD), mrSparkzz.nextMessage());
+        performCommand(mrSparkzz, "shop remove stick 1");
+        assertEquals(Notifier.compose(MATERIAL_MISSING_STORE, Collections.singletonMap("material", Material.STICK)), mrSparkzz.nextMessage());
         printSuccessMessage("remove command test - material doesn't exist");
     }
 
@@ -110,7 +120,37 @@ public class RemoveCommandTest {
     @Order(5)
     void testRemoveCommand_InvalidMaterial() {
         performCommand(mrSparkzz, "shop remove emeral 1");
-        assertEquals("§cInvalid material (emeral)!", mrSparkzz.nextMessage());
+        assertEquals(Notifier.compose(INVALID_MATERIAL, Collections.singletonMap("material", "emeral")), mrSparkzz.nextMessage());
+        assertEquals("/shop [buy|sell|browse]", mrSparkzz.nextMessage());
         printSuccessMessage("remove command test - invalid material");
+    }
+
+    @Test
+    @DisplayName("Test Remove - main functionality - no store")
+    @Order(6)
+    void testRemoveCommand_NoStore() {
+        Store.DEFAULT_STORES.clear();
+        performCommand(mrSparkzz, "shop remove emerald 1");
+        assertEquals(Notifier.compose(Notifier.CipherKey.NO_STORE_FOUND, null), mrSparkzz.nextMessage());
+        printSuccessMessage("remove command test - no store");
+    }
+
+    @Test
+    @DisplayName("Test Remove - main functionality - insufficient inventory store")
+    @Order(7)
+    void testRemoveCommand_InsufficientInventoryStore() {
+        performCommand(mrSparkzz, "shop remove emerald 1000");
+        assertEquals(Notifier.compose(INSUFFICIENT_INV_STORE, Collections.singletonMap("material", Material.EMERALD)), mrSparkzz.nextMessage());
+        printSuccessMessage("remove command test - insufficient inventory store");
+    }
+
+    @Test
+    @DisplayName("Test Remove - main functionality - insufficient inventory player")
+    @Order(8)
+    void testRemoveCommand_InsufficientInventoryPlayer() {
+        mrSparkzz.getInventory().addItem(new ItemStack(Material.MILK_BUCKET, 2304));
+        performCommand(mrSparkzz, "shop remove emerald 64");
+        assertEquals(Notifier.compose(REMOVE_INSUFFICIENT_INV_PLAYER, Collections.singletonMap("material", Material.EMERALD)), mrSparkzz.nextMessage());
+        printSuccessMessage("remove command test - insufficient inventory player");
     }
 }

--- a/src/test/java/net/sparkzz/command/sub/SellCommandTest.java
+++ b/src/test/java/net/sparkzz/command/sub/SellCommandTest.java
@@ -31,33 +31,34 @@ class SellCommandTest {
 
         MockBukkit.loadWith(MockVault.class, new PluginDescriptionFile("Vault", "MOCK", "net.sparkzz.shops.mocks.MockVault"));
         MockBukkit.load(Shops.class);
+        loadConfig();
 
         mrSparkzz = server.addPlayer("MrSparkzz");
         player2 = server.addPlayer();
 
         mrSparkzz.setOp(true);
-        Store.setDefaultStore((store = new Store("BetterBuy", mrSparkzz.getUniqueId())));
+        Store.setDefaultStore(mrSparkzz.getWorld(), (store = new Store("BetterBuy", mrSparkzz.getUniqueId())));
     }
 
     @AfterAll
     static void tearDown() {
-        // Stop the mock server
         MockBukkit.unmock();
-        Store.setDefaultStore(null);
+        unLoadConfig();
+        Store.DEFAULT_STORES.clear();
         Store.STORES.clear();
     }
 
     @BeforeEach
     void setUpSellCommand() {
-        Store.getDefaultStore().addItem(emeralds.getType(), 0, -1, 2D, 1.5D);
-        Store.getDefaultStore().setBalance(100);
+        Store.getDefaultStore(mrSparkzz.getWorld()).get().addItem(emeralds.getType(), 0, -1, 2D, 1.5D);
+        Store.getDefaultStore(mrSparkzz.getWorld()).get().setBalance(100);
         mrSparkzz.getInventory().addItem(emeralds);
         // TODO: Shops.getEconomy().depositPlayer(mrSparkzz, 50);
     }
 
     @AfterEach
     void tearDownShop() {
-        Store.getDefaultStore().getItems().clear();
+        Store.getDefaultStore(mrSparkzz.getWorld()).get().getItems().clear();
     }
 
     @Test
@@ -76,12 +77,12 @@ class SellCommandTest {
     void testSellCommand() {
         Material material = emeralds.getType();
         int quantity = 1;
-        double price = Store.getDefaultStore().getSellPrice(material);
+        double price = Store.getDefaultStore(mrSparkzz.getWorld()).get().getSellPrice(material);
 
         performCommand(mrSparkzz, "shop sell emerald " + quantity);
         assertEquals(String.format("%sSuccess! You have sold %s%s%s of %s%s%s for %s$%.2f%s.",
                 GREEN, GOLD, quantity, GREEN, GOLD, material, GREEN, GOLD, price * quantity, GREEN), mrSparkzz.nextMessage());
-        assertEquals(25, Store.getDefaultStore().getBalance());
+        assertEquals(25, Store.getDefaultStore(mrSparkzz.getWorld()).get().getBalance());
         assertEquals(150, Shops.getEconomy().getBalance(mrSparkzz));
         printSuccessMessage("sell command test");
     }

--- a/src/test/java/net/sparkzz/command/sub/TransferCommandTest.java
+++ b/src/test/java/net/sparkzz/command/sub/TransferCommandTest.java
@@ -36,6 +36,7 @@ class TransferCommandTest {
 
         MockBukkit.loadWith(MockVault.class, new PluginDescriptionFile("Vault", "MOCK", "net.sparkzz.shops.mocks.MockVault"));
         MockBukkit.load(Shops.class);
+        loadConfig();
 
         Shops.setMockServer(server);
         mrSparkzz = server.addPlayer("MrSparkzz");
@@ -46,14 +47,14 @@ class TransferCommandTest {
 
     @AfterAll
     static void tearDown() {
-        // Stop the mock server
         MockBukkit.unmock();
-        Store.setDefaultStore(null);
+        unLoadConfig();
+        Store.DEFAULT_STORES.clear();
     }
 
     @BeforeEach
     void setUpShop() {
-        Store.setDefaultStore((store = new Store("BetterBuy", mrSparkzz.getUniqueId())));
+        Store.setDefaultStore(mrSparkzz.getWorld(), (store = new Store("BetterBuy", mrSparkzz.getUniqueId())));
     }
 
     @AfterEach

--- a/src/test/java/net/sparkzz/command/sub/UpdateCommandTest.java
+++ b/src/test/java/net/sparkzz/command/sub/UpdateCommandTest.java
@@ -7,6 +7,7 @@ import net.sparkzz.shops.Shops;
 import net.sparkzz.shops.Store;
 import net.sparkzz.shops.mocks.MockVault;
 import net.sparkzz.util.Cuboid;
+import net.sparkzz.util.Notifier;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -16,7 +17,8 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.*;
 
 import static net.sparkzz.shops.TestHelper.*;
-import static org.bukkit.ChatColor.*;
+import static org.bukkit.ChatColor.GOLD;
+import static org.bukkit.ChatColor.GREEN;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings("SpellCheckingInspection")
@@ -36,6 +38,7 @@ class UpdateCommandTest {
 
         MockBukkit.loadWith(MockVault.class, new PluginDescriptionFile("Vault", "MOCK", "net.sparkzz.shops.mocks.MockVault"));
         MockBukkit.load(Shops.class);
+        loadConfig();
 
         mrSparkzz = server.addPlayer("MrSparkzz");
         mrSparkzz.setOp(true);
@@ -48,9 +51,9 @@ class UpdateCommandTest {
 
     @AfterAll
     static void tearDown() {
-        // Stop the mock server
         MockBukkit.unmock();
-        Store.setDefaultStore(null);
+        unLoadConfig();
+        Store.DEFAULT_STORES.clear();
     }
 
     @BeforeEach
@@ -341,7 +344,7 @@ class UpdateCommandTest {
         void testUpdateCommand_Permissions() {
             cmdUse = false;
             performCommand(player, "shop update shop-name TestShop99");
-            assertEquals(String.format("%sYou do not have permission to use this command!", RED), player.nextMessage());
+            assertEquals(Notifier.compose(Notifier.CipherKey.NO_PERMS_CMD, null), player.nextMessage());
             printSuccessMessage("update command permission check");
         }
 

--- a/src/test/java/net/sparkzz/command/sub/WithdrawCommandTest.java
+++ b/src/test/java/net/sparkzz/command/sub/WithdrawCommandTest.java
@@ -28,26 +28,27 @@ class WithdrawCommandTest {
 
         MockBukkit.loadWith(MockVault.class, new PluginDescriptionFile("Vault", "MOCK", "net.sparkzz.shops.mocks.MockVault"));
         MockBukkit.load(Shops.class);
+        loadConfig();
 
         mrSparkzz = server.addPlayer("MrSparkzz");
         player2 = server.addPlayer();
 
         mrSparkzz.setOp(true);
-        Store.setDefaultStore((store = new Store("BetterBuy", mrSparkzz.getUniqueId())));
+        Store.setDefaultStore(mrSparkzz.getWorld(), (store = new Store("BetterBuy", mrSparkzz.getUniqueId())));
     }
 
     @AfterAll
     static void tearDown() {
-        // Stop the mock server
         MockBukkit.unmock();
-        Store.setDefaultStore(null);
+        unLoadConfig();
+        Store.DEFAULT_STORES.clear();
         Store.STORES.clear();
     }
 
     @BeforeEach
     void setUpWithdrawCommand() {
         // TODO: Shops.getEconomy().depositPlayer(mrSparkzz, 50);
-        Store.getDefaultStore().setBalance(125);
+        Store.getDefaultStore(mrSparkzz.getWorld()).get().setBalance(125);
     }
 
     @AfterEach

--- a/src/test/java/net/sparkzz/event/EntranceListenerTest.java
+++ b/src/test/java/net/sparkzz/event/EntranceListenerTest.java
@@ -20,8 +20,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
-import static net.sparkzz.shops.TestHelper.printMessage;
-import static net.sparkzz.shops.TestHelper.printSuccessMessage;
+import static net.sparkzz.shops.TestHelper.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -40,6 +39,7 @@ public class EntranceListenerTest {
 
         MockBukkit.loadWith(MockVault.class, new PluginDescriptionFile("Vault", "MOCK", "net.sparkzz.shops.mocks.MockVault"));
         MockBukkit.load(Shops.class);
+        loadConfig();
         World world = server.createWorld(WorldCreator.name("main-world"));
         otherWorld = server.createWorld(WorldCreator.name("other-world"));
         home = new Location(world, 0D, 0D, 0D);
@@ -49,15 +49,15 @@ public class EntranceListenerTest {
         mrSparkzz = server.addPlayer("MrSparkzz");
 
         mrSparkzz.setLocation(new Location(world, 0D, 0D, 0D));
-        Store.setDefaultStore(new Store("BetterBuy", mrSparkzz.getUniqueId(), new Cuboid(world, 10D, 10D, 10D, 20D, 20D, 20D)));
-        Store.setDefaultStore(new Store("WorstBuy", mrSparkzz.getUniqueId(), new Cuboid(null, 10D, 10D, 10D, 20D, 20D, 20D)));
+        Store.setDefaultStore(mrSparkzz.getWorld(), new Store("BetterBuy", mrSparkzz.getUniqueId(), new Cuboid(world, 10D, 10D, 10D, 20D, 20D, 20D)));
+        new Store("WorstBuy", mrSparkzz.getUniqueId(), new Cuboid(null, 10D, 10D, 10D, 20D, 20D, 20D));
     }
 
     @AfterAll
     static void tearDown() {
-        // Stop the mock server
         MockBukkit.unmock();
-        Store.setDefaultStore(null);
+        unLoadConfig();
+        Store.DEFAULT_STORES.clear();
         Store.STORES.clear();
     }
 

--- a/src/test/java/net/sparkzz/shops/StoreTest.java
+++ b/src/test/java/net/sparkzz/shops/StoreTest.java
@@ -75,7 +75,7 @@ public class StoreTest {
     void testRemoveFunds_MoreThanStoreBalance() {
         Store.getDefaultStore(null).get().removeFunds(10D);
         assertEquals(0D, Store.getDefaultStore(null).get().getBalance());
-        printSuccessMessage("remove funds - more than stpre balance");
+        printSuccessMessage("remove funds - more than store balance");
     }
 
     @Test

--- a/src/test/java/net/sparkzz/shops/StoreTest.java
+++ b/src/test/java/net/sparkzz/shops/StoreTest.java
@@ -18,8 +18,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
-import static net.sparkzz.shops.TestHelper.printMessage;
-import static net.sparkzz.shops.TestHelper.printSuccessMessage;
+import static net.sparkzz.shops.TestHelper.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DisplayName("Entrance Listener")
@@ -35,29 +34,30 @@ public class StoreTest {
 
         MockBukkit.loadWith(MockVault.class, new PluginDescriptionFile("Vault", "MOCK", "net.sparkzz.shops.mocks.MockVault"));
         MockBukkit.load(Shops.class);
+        loadConfig();
 
         Shops.setMockServer(server);
 
-        Store.setDefaultStore(new Store("BetterBuy"));
+        Store.setDefaultStore(null, new Store("BetterBuy"));
     }
 
     @AfterAll
     static void tearDown() {
-        // Stop the mock server
         MockBukkit.unmock();
+        unLoadConfig();
     }
 
     @AfterEach
     void reset() {
         Store.STORES.clear();
-        Store.setDefaultStore(new Store("BetterBuy"));
+        Store.setDefaultStore(null, new Store("BetterBuy"));
     }
 
     @Test
     @DisplayName("Test get buy price - material not in store")
     @Order(1)
     void testGetBuyPrice_MaterialNotInStore() {
-        assertEquals(-1D, Store.getDefaultStore().getBuyPrice(Material.BEEF));
+        assertEquals(-1D, Store.getDefaultStore(null).get().getBuyPrice(Material.BEEF));
         printSuccessMessage("get buy price test - material not in store");
     }
 
@@ -65,7 +65,7 @@ public class StoreTest {
     @DisplayName("Test get sell price - material not in shop")
     @Order(2)
     void testGetSellPrice_MaterialNotInStore() {
-        assertEquals(-1D, Store.getDefaultStore().getSellPrice(Material.BEEF));
+        assertEquals(-1D, Store.getDefaultStore(null).get().getSellPrice(Material.BEEF));
         printSuccessMessage("get sell price test - material not in store");
     }
 
@@ -73,8 +73,8 @@ public class StoreTest {
     @DisplayName("Test removing funds - more than store balance")
     @Order(3)
     void testRemoveFunds_MoreThanStoreBalance() {
-        Store.getDefaultStore().removeFunds(10D);
-        assertEquals(0D, Store.getDefaultStore().getBalance());
+        Store.getDefaultStore(null).get().removeFunds(10D);
+        assertEquals(0D, Store.getDefaultStore(null).get().getBalance());
         printSuccessMessage("remove funds - more than stpre balance");
     }
 
@@ -82,9 +82,9 @@ public class StoreTest {
     @DisplayName("Test removing funds")
     @Order(4)
     void testRemoveFunds() {
-        Store.getDefaultStore().setBalance(15.52D);
-        Store.getDefaultStore().removeFunds(10D);
-        assertEquals(5.52D, Store.getDefaultStore().getBalance());
+        Store.getDefaultStore(null).get().setBalance(15.52D);
+        Store.getDefaultStore(null).get().removeFunds(10D);
+        assertEquals(5.52D, Store.getDefaultStore(null).get().getBalance());
         printSuccessMessage("remove funds");
     }
 
@@ -92,9 +92,9 @@ public class StoreTest {
     @DisplayName("Test removing item stack")
     @Order(5)
     void testRemoveItemStack() {
-        Store.getDefaultStore().addItem(new ItemStack(Material.SNOWBALL, 20));
-        Store.getDefaultStore().removeItem(new ItemStack(Material.SNOWBALL, 15));
-        assertEquals(5, Store.getDefaultStore().getAttributes(Material.SNOWBALL).get("quantity"));
+        Store.getDefaultStore(null).get().addItem(new ItemStack(Material.SNOWBALL, 20));
+        Store.getDefaultStore(null).get().removeItem(new ItemStack(Material.SNOWBALL, 15));
+        assertEquals(5, Store.getDefaultStore(null).get().getAttributes(Material.SNOWBALL).get("quantity"));
         printSuccessMessage("remove item stack");
     }
 
@@ -104,8 +104,8 @@ public class StoreTest {
     void testSetCuboidLocation() {
         World world = server.createWorld(WorldCreator.name("world"));
         Cuboid cuboid = new Cuboid(world, 1D, 1D, 1D, 2D, 2D, 2D);
-        Store.getDefaultStore().setCuboidLocation(cuboid);
-        assertEquals(cuboid, Store.getDefaultStore().getCuboidLocation());
+        Store.getDefaultStore(null).get().setCuboidLocation(cuboid);
+        assertEquals(cuboid, Store.getDefaultStore(null).get().getCuboidLocation());
         printSuccessMessage("set cuboid location");
     }
 }

--- a/src/test/java/net/sparkzz/util/ConfigTest.java
+++ b/src/test/java/net/sparkzz/util/ConfigTest.java
@@ -57,7 +57,6 @@ public class ConfigTest {
         Config.setMaxVolume(1024D);
         Config.setOffLimitsAreas(cuboids);
         Config.setMaxOwnedStores(2);
-        Config.setDefaultStore(null, null);
         unLoadConfig();
         Store.STORES.clear();
         Store.DEFAULT_STORES.clear();
@@ -150,7 +149,9 @@ public class ConfigTest {
         Config.setDefaultStore(world, otherStore);
         Config.setDefaultStore(server.getWorld("null"), store);
         assertTrue(Config.getDefaultStore(null).isPresent());
+        assertTrue(Config.getDefaultStore(world).isPresent());
         assertEquals(store, Config.getDefaultStore(null).get());
+        assertEquals(store, Config.getDefaultStore(world).get());
         printSuccessMessage("setting default store for all world");
     }
 

--- a/src/test/java/net/sparkzz/util/ConfigTest.java
+++ b/src/test/java/net/sparkzz/util/ConfigTest.java
@@ -3,9 +3,11 @@ package net.sparkzz.util;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import net.sparkzz.shops.Shops;
+import net.sparkzz.shops.Store;
 import org.bukkit.World;
 import org.bukkit.WorldCreator;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
@@ -17,22 +19,27 @@ import java.util.List;
 
 import static net.sparkzz.shops.TestHelper.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("Config Test")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class ConfigTest {
 
+    private static ServerMock server;
+    private static Store store, otherStore;
     private static World world, world_nether, world_the_end;
 
     @BeforeAll
     static void setUp() {
         printMessage("==[ TEST CONFIG ]==");
-        ServerMock server = MockBukkit.getOrCreateMock();
+        server = MockBukkit.getOrCreateMock();
         MockBukkit.load(Shops.class);
         loadConfig();
         world = server.createWorld(WorldCreator.name("world"));
         world_nether = server.createWorld(WorldCreator.name("world_nether"));
         world_the_end = server.createWorld(WorldCreator.name("world_the_end"));
+        store = new Store("TestStore");
+        otherStore = new Store("TestStore2");
     }
 
     @AfterAll
@@ -50,7 +57,15 @@ public class ConfigTest {
         Config.setMaxVolume(1024D);
         Config.setOffLimitsAreas(cuboids);
         Config.setMaxOwnedStores(2);
+        Config.setDefaultStore(null, null);
         unLoadConfig();
+        Store.STORES.clear();
+        Store.DEFAULT_STORES.clear();
+    }
+
+    @AfterEach
+    void resetConfig() {
+        Config.setDefaultStore(null, null);
     }
 
     @Test
@@ -126,5 +141,29 @@ public class ConfigTest {
         Config.setMaxOwnedStores(5);
         assertEquals(5, Config.getMaxOwnedStores());
         printSuccessMessage("setting maximum owned stores");
+    }
+
+    @Test
+    @DisplayName("Test set default store for all worlds")
+    @Order(8)
+    void testGlobalDefaultStore() {
+        Config.setDefaultStore(world, otherStore);
+        Config.setDefaultStore(server.getWorld("null"), store);
+        assertTrue(Config.getDefaultStore(null).isPresent());
+        assertEquals(store, Config.getDefaultStore(null).get());
+        printSuccessMessage("setting default store for all world");
+    }
+
+    @Test
+    @DisplayName("Test set default store for specific worlds")
+    @Order(9)
+    void testDefaultStore_PerWorld() {
+        Config.setDefaultStore(world, store);
+        Config.setDefaultStore(world_nether, otherStore);
+        assertTrue(Config.getDefaultStore(world).isPresent());
+        assertTrue(Config.getDefaultStore(world_nether).isPresent());
+        assertEquals(store, Config.getDefaultStore(world).get());
+        assertEquals(otherStore, Config.getDefaultStore(world_nether).get());
+        printSuccessMessage("setting default store for specific world");
     }
 }

--- a/src/test/java/net/sparkzz/util/CuboidTest.java
+++ b/src/test/java/net/sparkzz/util/CuboidTest.java
@@ -44,7 +44,7 @@ public class CuboidTest {
     @AfterAll
     static void tearDown() {
         MockBukkit.unmock();
-        Store.setDefaultStore(null);
+        Store.DEFAULT_STORES.clear();
     }
 
     @Test

--- a/src/test/java/net/sparkzz/util/InventoryManagementSystemTest.java
+++ b/src/test/java/net/sparkzz/util/InventoryManagementSystemTest.java
@@ -22,8 +22,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import java.util.List;
 
-import static net.sparkzz.shops.TestHelper.printMessage;
-import static net.sparkzz.shops.TestHelper.printSuccessMessage;
+import static net.sparkzz.shops.TestHelper.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings("SpellCheckingInspection")
@@ -44,24 +43,26 @@ public class InventoryManagementSystemTest {
 
         MockBukkit.loadWith(MockVault.class, new PluginDescriptionFile("Vault", "MOCK", "net.sparkzz.shops.mocks.MockVault"));
         MockBukkit.load(Shops.class);
+        loadConfig();
 
         mrSparkzz = server.addPlayer("MrSparkzz");
 
         mrSparkzz.setOp(true);
-        Store.setDefaultStore(store = new Store("BetterBuy", mrSparkzz.getUniqueId()));
+        Store.setDefaultStore(mrSparkzz.getWorld(), (store = new Store("BetterBuy", mrSparkzz.getUniqueId())));
         secondaryStore = new Store("SecondaryStore", mrSparkzz.getUniqueId(), new Cuboid(server.getWorld("world"), -20D, -20D, -20D, 20D, 20D, 20D));
     }
 
     @AfterAll
     static void tearDown() {
         MockBukkit.unmock();
-        Store.setDefaultStore(null);
+        unLoadConfig();
+        Store.DEFAULT_STORES.clear();
         Store.STORES.clear();
     }
 
     @BeforeEach
     void setUpIMS() {
-        Store.setDefaultStore(store);
+        Store.setDefaultStore(null, store);
         store.addItem(emeralds.getType(), emeralds.getAmount(), 128, 1, 1);
     }
 
@@ -249,7 +250,7 @@ public class InventoryManagementSystemTest {
     void testIdentifyStore_WithinSecondaryStore() {
         mrSparkzz.setLocation(new Location(server.getWorld("world"), 0D, 0D, 0D));
 
-        assertEquals(secondaryStore, InventoryManagementSystem.locateCurrentStore(mrSparkzz));
+        assertEquals(secondaryStore, InventoryManagementSystem.locateCurrentStore(mrSparkzz).orElse(null));
         printSuccessMessage("IMS - identify store - within secondary store");
     }
 
@@ -259,7 +260,7 @@ public class InventoryManagementSystemTest {
     void testIdentifyStore_NotWithinSecondaryStore() {
         mrSparkzz.setLocation(new Location(server.getWorld("world"), 21D, 0D, 0D));
 
-        assertEquals(store, InventoryManagementSystem.locateCurrentStore(mrSparkzz));
+        assertEquals(store, InventoryManagementSystem.locateCurrentStore(mrSparkzz).orElse(null));
         printSuccessMessage("IMS - identify store - within default store");
     }
 
@@ -268,10 +269,10 @@ public class InventoryManagementSystemTest {
     @Order(20)
     void testIdentifyStore_NotWithinAnyStore() {
         mrSparkzz.setLocation(new Location(server.getWorld("not-a-world"), 0D, 0D, 0D));
-        Store.setDefaultStore(null);
+        Store.DEFAULT_STORES.clear();
 
         System.out.println(mrSparkzz.getWorld());
-        assertNull(InventoryManagementSystem.locateCurrentStore(mrSparkzz));
+        assertNull(InventoryManagementSystem.locateCurrentStore(mrSparkzz).orElse(null));
         printSuccessMessage("IMS - identify store - not within secondary store");
     }
 }

--- a/src/test/java/net/sparkzz/util/InventoryManagementSystemTest.java
+++ b/src/test/java/net/sparkzz/util/InventoryManagementSystemTest.java
@@ -8,6 +8,7 @@ import net.sparkzz.shops.Store;
 import net.sparkzz.shops.mocks.MockVault;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.WorldCreator;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.junit.jupiter.api.AfterAll;
@@ -48,6 +49,8 @@ public class InventoryManagementSystemTest {
         mrSparkzz = server.addPlayer("MrSparkzz");
 
         mrSparkzz.setOp(true);
+        server.createWorld(WorldCreator.name("world"));
+        server.createWorld(WorldCreator.name("world_nether"));
         Store.setDefaultStore(mrSparkzz.getWorld(), (store = new Store("BetterBuy", mrSparkzz.getUniqueId())));
         secondaryStore = new Store("SecondaryStore", mrSparkzz.getUniqueId(), new Cuboid(server.getWorld("world"), -20D, -20D, -20D, 20D, 20D, 20D));
     }
@@ -248,6 +251,7 @@ public class InventoryManagementSystemTest {
     @DisplayName("Test IMS - identify store - within secondary store")
     @Order(18)
     void testIdentifyStore_WithinSecondaryStore() {
+        Store.setDefaultStore(null, null);
         mrSparkzz.setLocation(new Location(server.getWorld("world"), 0D, 0D, 0D));
 
         assertEquals(secondaryStore, InventoryManagementSystem.locateCurrentStore(mrSparkzz).orElse(null));
@@ -273,6 +277,17 @@ public class InventoryManagementSystemTest {
 
         System.out.println(mrSparkzz.getWorld());
         assertNull(InventoryManagementSystem.locateCurrentStore(mrSparkzz).orElse(null));
+        printSuccessMessage("IMS - identify store - not within secondary store");
+    }
+
+    @Test
+    @DisplayName("Test IMS - identify store - inter-global default in another world")
+    @Order(21)
+    void testIdentifyStore_InterGlobalDefaultInAnotherWorld() {
+        mrSparkzz.setLocation(new Location(server.getWorld("world_nether"), 0D, 0D, 0D));
+
+        System.out.println(mrSparkzz.getWorld());
+        assertEquals(store, InventoryManagementSystem.locateCurrentStore(mrSparkzz).orElse(null));
         printSuccessMessage("IMS - identify store - not within secondary store");
     }
 }

--- a/src/test/java/net/sparkzz/util/NotifierTest.java
+++ b/src/test/java/net/sparkzz/util/NotifierTest.java
@@ -46,7 +46,7 @@ class NotifierTest {
     @AfterAll
     static void tearDown() {
         MockBukkit.unmock();
-        Store.setDefaultStore(null);
+        Store.DEFAULT_STORES.clear();
         unLoadConfig();
     }
 

--- a/src/test/java/net/sparkzz/util/TransactionTest.java
+++ b/src/test/java/net/sparkzz/util/TransactionTest.java
@@ -11,8 +11,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.junit.jupiter.api.*;
 
-import static net.sparkzz.shops.TestHelper.printMessage;
-import static net.sparkzz.shops.TestHelper.printSuccessMessage;
+import static net.sparkzz.shops.TestHelper.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -37,15 +36,17 @@ public class TransactionTest {
 
         mrSparkzz = server.addPlayer("MrSparkzz");
         player = server.addPlayer();
+        loadConfig();
 
         mrSparkzz.setOp(true);
-        Store.setDefaultStore(store = new Store("BetterBuy", mrSparkzz.getUniqueId()));
+        Store.setDefaultStore(mrSparkzz.getWorld(), (store = new Store("BetterBuy", mrSparkzz.getUniqueId())));
     }
 
     @AfterAll
     static void tearDownAll() {
         MockBukkit.unmock();
-        Store.setDefaultStore(null);
+        unLoadConfig();
+        Store.DEFAULT_STORES.clear();
         Store.STORES.clear();
     }
 

--- a/src/test/resources/config.yml
+++ b/src/test/resources/config.yml
@@ -1,5 +1,4 @@
 store:
-  default: []
   max-owned-stores: 2
   min-dimensions:
     x: 3

--- a/src/test/resources/config.yml
+++ b/src/test/resources/config.yml
@@ -1,4 +1,5 @@
 store:
+  default: []
   max-owned-stores: 2
   min-dimensions:
     x: 3


### PR DESCRIPTION
This feature implements the ability to set whole-world stores, as well as an inter-global default store using 'null' as the key (with single quotes) and the UUID of the store to override all other defaults. The Store UUID can be found in the `data.shops` file generated after creating your first store.

To set a default, in the config, set these options in the `config.yml` file:
```yml
store:
  default:
    world: a4ffa6ca-611a-4786-a80a-ec03e71eddd2 #sets the default store of world "world" to this Store's UUID
    'null': d19ba2a1-0a24-4977-baee-638ee15f2ccf #overrides 'world' with this inter-global Store's UUID
```

_Issues_
* closes GH-24
* resolves GH-27
* resolves GH-28